### PR TITLE
Add eslint and implement prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,71 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "tsconfig.json",
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ["@typescript-eslint", "cflint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended",
+  ],
+  rules: {
+    "@typescript-eslint/explicit-function-return-type": 2,
+    "@typescript-eslint/member-ordering": 2,
+    "@typescript-eslint/naming-convention": [
+      2,
+      {
+        selector: "default",
+        format: ["camelCase"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+      {
+        selector: "variable",
+        format: ["camelCase", "UPPER_CASE"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+      {
+        selector: "typeLike",
+        format: ["PascalCase"],
+      },
+    ],
+    "@typescript-eslint/no-unnecessary-condition": 2,
+    "@typescript-eslint/no-unsafe-call": 2,
+    "@typescript-eslint/no-unsafe-member-access": 2,
+    "@typescript-eslint/no-unsafe-return": 2,
+    "@typescript-eslint/no-unused-vars": 2,
+    "@typescript-eslint/prefer-nullish-coalescing": 2,
+    "cflint/no-this-assignment": 2,
+    curly: [2, "all"],
+    eqeqeq: "error",
+    "import/newline-after-import": ["error", { count: 1 }],
+    "max-len": 2,
+    "no-alert": 2,
+    "no-invalid-this": 2,
+    "no-var": 2,
+    "no-unused-expressions": 2,
+    quotes: ["error", "double"],
+    "sort-imports": [
+      "error",
+      {
+        ignoreCase: false,
+        ignoreDeclarationSort: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+      },
+    ],
+    "spaced-comment": 2,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,25 +1,38 @@
 {
-	"name": "three.ts",
-	"version": "0.0.0",
-	"description": "Three.ts Prototype",
-	"keywords": [],
-	"author": "Ben Houston",
-	"license": "ISC",
-	"type": "module",
-	"main": "index.ts",
-	"module": "index.ts",
-	"scripts": {
-		"build": "tsc",
-		"watch": "npm run build -- --watch",
-		"start": "es-dev-server --node-resolution",
-		"dev": "npm run watch & npm start",
-		"prettier": "npx prettier --single-quote --use-tabs --trailing-comma all --write docs package.json \"./src/**/*.ts\""
-	},
-	"devDependencies": {
-		"es-dev-server": "^1.53.0",
-		"typescript": "^3.9.3"
-	},
-	"dependencies": {
-		"prettier": "^2.0.5"
-	}
+  "name": "three.ts",
+  "version": "0.0.0",
+  "description": "Three.ts Prototype",
+  "keywords": [],
+  "author": "Ben Houston",
+  "license": "ISC",
+  "type": "module",
+  "main": "index.ts",
+  "module": "index.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "npm run build -- --watch",
+    "start": "es-dev-server --node-resolution",
+    "dev": "npm run watch & npm start",
+    "prettier": "npx prettier --single-quote --use-tabs --trailing-comma all --write docs package.json \"./src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "@typescript-eslint/parser": "^3.1.0",
+    "es-dev-server": "^1.53.0",
+    "eslint": "^7.1.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-cflint": "^1.0.0",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-prettier": "^3.1.3",
+    "typescript": "^3.9.3"
+  },
+  "dependencies": {
+    "prettier": "^2.0.5"
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": false
+  }
 }


### PR DESCRIPTION
This implement prettier and adds eslint on top (tslint being deprecated for the use of a ton of modules for eslint, hence the size of that config file...)

:information_source: The current source code uses 1 tab spacing everywhere but this PR advocates for 2 spaces.

:warning: if accepted, this PR will need a follow up to actually lint all files consistently. I didn't want to introduce that there yet for the sake of clarity.

