### PR TITLE
Favour VSCode over ESLint for import sorting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     "no-unused-expressions": 2,
     quotes: ["error", "double"],
     "sort-imports": [
-      "error",
+      0,
       {
         ignoreCase: false,
         ignoreDeclarationSort: false,

--- a/src/geometry/Attribute.ts
+++ b/src/geometry/Attribute.ts
@@ -5,10 +5,10 @@
 // * @bhouston
 //
 
-import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
-import { BufferTarget } from "../renderers/webgl2/BufferTarget";
-import { IPoolUser } from "../renderers/Pool";
 import { generateUUID } from "../core/generateUuid";
+import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
+import { IPoolUser } from "../renderers/Pool";
+import { BufferTarget } from "../renderers/webgl2/BufferTarget";
 
 export class Attribute implements IIdentifiable, IVersionable, IDisposable, IPoolUser {
   disposed = false;

--- a/src/geometry/Geometry.ts
+++ b/src/geometry/Geometry.ts
@@ -6,8 +6,8 @@
 //
 
 import { IDisposable, IVersionable } from "../core/types";
-import { AttributeAccessor } from "./AttributeAccessor";
 import { PrimitiveType } from "../renderers/webgl2/PrimitiveType";
+import { AttributeAccessor } from "./AttributeAccessor";
 
 class NamedAttributeAccessor {
   name: string;

--- a/src/geometry/primitives/Box.ts
+++ b/src/geometry/primitives/Box.ts
@@ -5,9 +5,9 @@
 // * @bhouston
 //
 
+import { Vector3 } from "../../math/Vector3";
 import { Float32AttributeAccessor, Int32AttributeAccessor } from "../AttributeAccessor";
 import { Geometry } from "../Geometry";
-import { Vector3 } from "../../math/Vector3";
 
 export function box(
   width = 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,9 @@ import {
   VertexArrayObject,
   VertexAttributeGeometry,
 } from "./renderers/webgl2";
-import { Texture, TextureAccessor } from "./textures";
-
-import debug_vertex from "./renderers/webgl2/shaders/materials/debug/vertex.glsl";
 import debug_fragment from "./renderers/webgl2/shaders/materials/debug/fragment.glsl";
+import debug_vertex from "./renderers/webgl2/shaders/materials/debug/vertex.glsl";
+import { Texture, TextureAccessor } from "./textures";
 
 async function test(): Promise<void> {
   // setup webgl2

--- a/src/materials/Material.ts
+++ b/src/materials/Material.ts
@@ -1,5 +1,5 @@
-import { ICloneable, ICopyable, IDisposable, IIdentifiable, IVersionable } from "../core/types";
 import { generateUUID } from "../core/generateUuid";
+import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
 
 export class Material implements IIdentifiable, IVersionable, IDisposable {
   disposed = false;

--- a/src/materials/PhysicalMaterial.ts
+++ b/src/materials/PhysicalMaterial.ts
@@ -5,9 +5,9 @@
 // * @bhouston
 //
 
+import { ICloneable, ICopyable } from "../core/types";
 import { Color } from "../math/Color";
 import { TextureAccessor } from "../textures/TextureAccessor";
-import { ICloneable, ICopyable } from "../core/types";
 import { Blending } from "./Blending";
 import { Material } from "./Material";
 import { MaterialOutputs } from "./MaterialOutputs";

--- a/src/materials/ShaderMaterial.ts
+++ b/src/materials/ShaderMaterial.ts
@@ -5,9 +5,9 @@
 // * @bhouston
 //
 
+import { generateUUID } from "../core/generateUuid";
 import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
 import { IPoolUser } from "../renderers/Pool";
-import { generateUUID } from "../core/generateUuid";
 
 export class ShaderMaterial implements IIdentifiable, IVersionable, IDisposable, IPoolUser {
   uuid: string = generateUUID();

--- a/src/math/Color.ts
+++ b/src/math/Color.ts
@@ -5,8 +5,8 @@
 // * @bhouston
 //
 
-import { IPrimitive } from "./IPrimitive";
 import { hashFloat3 } from "../core/hash";
+import { IPrimitive } from "./IPrimitive";
 
 function hue2rgb(p: number, q: number, t: number): number {
   if (t < 0) {

--- a/src/math/Euler3.ts
+++ b/src/math/Euler3.ts
@@ -1,7 +1,7 @@
+import { hashFloat4 } from "../core/hash";
 import { IPrimitive } from "./IPrimitive";
 import { Matrix4 } from "./Matrix4";
 import { Quaternion } from "./Quaternion";
-import { hashFloat4 } from "../core/hash";
 
 export enum EulerOrder {
   XYZ,

--- a/src/math/Matrix3.ts
+++ b/src/math/Matrix3.ts
@@ -5,11 +5,11 @@
 // * @bhouston
 //
 
+import { hashFloatArray } from "../core/hash";
 import { IPrimitive } from "./IPrimitive";
 import { Matrix4 } from "./Matrix4";
 import { Vector2 } from "./Vector2";
 import { Vector3 } from "./Vector3";
-import { hashFloatArray } from "../core/hash";
 
 export class Matrix3 implements IPrimitive<Matrix3> {
   elements: number[] = [1, 0, 0, 0, 1, 0, 0, 0, 1];

--- a/src/math/Matrix4.ts
+++ b/src/math/Matrix4.ts
@@ -5,11 +5,11 @@
 // * @bhouston
 //
 
+import { hashFloatArray } from "../core/hash";
 import { Euler3, EulerOrder } from "./Euler3";
 import { IPrimitive } from "./IPrimitive";
 import { Quaternion } from "./Quaternion";
 import { Vector3 } from "./Vector3";
-import { hashFloatArray } from "../core/hash";
 
 export class Matrix4 implements IPrimitive<Matrix4> {
   elements: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];

--- a/src/math/Quaternion.ts
+++ b/src/math/Quaternion.ts
@@ -5,11 +5,11 @@
 // * @bhouston
 //
 
+import { hashFloat4 } from "../core/hash";
 import { Euler3, EulerOrder } from "./Euler3";
 import { IPrimitive } from "./IPrimitive";
 import { Matrix4 } from "./Matrix4";
 import { Vector3 } from "./Vector3";
-import { hashFloat4 } from "../core/hash";
 
 export class Quaternion implements IPrimitive<Quaternion> {
   constructor(public x = 0, public y = 0, public z = 0, public w = 1) {}

--- a/src/math/Vector2.ts
+++ b/src/math/Vector2.ts
@@ -5,8 +5,8 @@
 // * @bhouston
 //
 
-import { IPrimitive } from "./IPrimitive";
 import { hashFloat2 } from "../core/hash";
+import { IPrimitive } from "./IPrimitive";
 
 export class Vector2 implements IPrimitive<Vector2> {
   constructor(public x = 0, public y = 0) {}

--- a/src/math/Vector3.ts
+++ b/src/math/Vector3.ts
@@ -5,9 +5,9 @@
 // * @bhouston
 //
 
+import { hashFloat3 } from "../core/hash";
 import { IPrimitive } from "./IPrimitive";
 import { Matrix4 } from "./Matrix4";
-import { hashFloat3 } from "../core/hash";
 
 export class Vector3 implements IPrimitive<Vector3> {
   constructor(public x = 0, public y = 0, public z = 0) {}

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -5,13 +5,13 @@
 // * @bhouston
 //
 
+import { generateUUID } from "../core/generateUuid";
 import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
 import { Euler3 } from "../math/Euler3";
 import { Matrix4 } from "../math/Matrix4";
-import { NodeCollection } from "./NodeCollection";
 import { Quaternion } from "../math/Quaternion";
 import { Vector3 } from "../math/Vector3";
-import { generateUUID } from "../core/generateUuid";
+import { NodeCollection } from "./NodeCollection";
 
 export class Node implements IIdentifiable, IVersionable, IDisposable {
   disposed = false;

--- a/src/nodes/cameras/OrthographicCamera.ts
+++ b/src/nodes/cameras/OrthographicCamera.ts
@@ -5,9 +5,9 @@
 // * @bhouston
 //
 
-import { Camera } from "./Camera";
 import { Matrix4 } from "../../math/Matrix4";
 import { Vector2 } from "../../math/Vector2";
+import { Camera } from "./Camera";
 
 export class OrthographicCamera extends Camera {
   height: number;

--- a/src/nodes/cameras/PerspectiveCamera.ts
+++ b/src/nodes/cameras/PerspectiveCamera.ts
@@ -5,8 +5,8 @@
 // * @bhouston
 //
 
-import { Camera } from "./Camera";
 import { Matrix4 } from "../../math/Matrix4";
+import { Camera } from "./Camera";
 
 export class PerspectiveCamera extends Camera {
   verticalFov: number;

--- a/src/renderers/webgl2/Buffer.ts
+++ b/src/renderers/webgl2/Buffer.ts
@@ -1,9 +1,9 @@
-import { Attribute } from "../../geometry/Attribute";
-import { BufferTarget } from "./BufferTarget";
 import { IDisposable } from "../../core/types";
+import { Attribute } from "../../geometry/Attribute";
 import { Pool } from "../Pool";
-import { RenderingContext } from "./RenderingContext";
+import { BufferTarget } from "./BufferTarget";
 import { BufferUsage } from "./BufferUsage";
+import { RenderingContext } from "./RenderingContext";
 
 export class Buffer implements IDisposable {
   disposed = false;

--- a/src/renderers/webgl2/BufferGeometry.ts
+++ b/src/renderers/webgl2/BufferGeometry.ts
@@ -7,9 +7,9 @@
 //
 
 import { Geometry } from "../../geometry/Geometry";
-import { RenderingContext } from "./RenderingContext";
 import { BufferAccessor } from "./BufferAccessor";
 import { PrimitiveType } from "./PrimitiveType";
+import { RenderingContext } from "./RenderingContext";
 
 class NamedVertexAttribute {
   name: string;

--- a/src/renderers/webgl2/Program.ts
+++ b/src/renderers/webgl2/Program.ts
@@ -5,13 +5,13 @@
 // * @bhouston
 //
 
-import { ProgramUniform, numTextureUnits } from "./ProgramUniform";
 import { IDisposable } from "../../core/types";
+import { ShaderMaterial } from "../../materials/ShaderMaterial";
 import { Pool } from "../Pool";
 import { ProgramAttribute } from "./ProgramAttribute";
+import { numTextureUnits, ProgramUniform } from "./ProgramUniform";
 import { RenderingContext } from "./RenderingContext";
 import { Shader } from "./Shader";
-import { ShaderMaterial } from "../../materials/ShaderMaterial";
 import { ShaderType } from "./ShaderType";
 
 export class Program implements IDisposable {

--- a/src/renderers/webgl2/ProgramUniform.ts
+++ b/src/renderers/webgl2/ProgramUniform.ts
@@ -1,10 +1,10 @@
 import { Color } from "../../math/Color";
 import { Matrix4 } from "../../math/Matrix4";
+import { Vector2 } from "../../math/Vector2";
+import { Vector3 } from "../../math/Vector3";
 import { Program } from "./Program";
 import { RenderingContext } from "./RenderingContext";
 import { TexImage2D } from "./TexImage2D";
-import { Vector2 } from "../../math/Vector2";
-import { Vector3 } from "../../math/Vector3";
 
 const GL2 = WebGL2RenderingContext;
 

--- a/src/renderers/webgl2/RenderingContext.ts
+++ b/src/renderers/webgl2/RenderingContext.ts
@@ -5,17 +5,17 @@
 // * @bhouston
 //
 
-import { Program, ProgramPool } from "./Program";
-import { BlendState } from "./BlendState";
 import { Box2 } from "../../math/Box2";
-import { BufferPool } from "./Buffer";
 import { Camera } from "../../nodes/cameras/Camera";
+import { Node } from "../../nodes/Node";
+import { BlendState } from "./BlendState";
+import { BufferPool } from "./Buffer";
 import { CanvasFramebuffer } from "./CanvasFramebuffer";
 import { ClearState } from "./ClearState";
 import { DepthTestState } from "./DepthTestState";
 import { Framebuffer } from "./Framebuffer";
 import { MaskState } from "./MaskState";
-import { Node } from "../../nodes/Node";
+import { Program, ProgramPool } from "./Program";
 import { TexImage2DPool } from "./TexImage2D";
 import { VirtualFramebuffer } from "./VirtualFramebuffer";
 

--- a/src/renderers/webgl2/TexImage2D.ts
+++ b/src/renderers/webgl2/TexImage2D.ts
@@ -6,14 +6,14 @@
 // * @bhouston
 //
 
-import { ArrayBufferImage, Texture } from "../../textures/Texture";
-import { DataType } from "../../textures/DataType";
 import { IDisposable } from "../../core/types";
+import { Vector2 } from "../../math/Vector2";
+import { DataType } from "../../textures/DataType";
 import { PixelFormat } from "../../textures/PixelFormat";
+import { ArrayBufferImage, Texture } from "../../textures/Texture";
 import { Pool } from "../Pool";
 import { RenderingContext } from "./RenderingContext";
 import { TexParameters } from "./TexParameters";
-import { Vector2 } from "../../math/Vector2";
 
 const GL = WebGLRenderingContext;
 

--- a/src/renderers/webgl2/VirtualFramebuffer.ts
+++ b/src/renderers/webgl2/VirtualFramebuffer.ts
@@ -9,7 +9,7 @@ import { IDisposable } from "../../core/types";
 import { Camera } from "../../nodes/cameras/Camera";
 import { Node } from "../../nodes/Node";
 import { sizeOfDataType } from "../../textures/DataType";
-import { PixelFormat, numPixelFormatComponents } from "../../textures/PixelFormat";
+import { numPixelFormatComponents, PixelFormat } from "../../textures/PixelFormat";
 import { AttachmentPoints } from "./AttachmentPoints";
 import { Attachments } from "./Attachments";
 import { ClearState } from "./ClearState";

--- a/src/renderers/webgl2/index.ts
+++ b/src/renderers/webgl2/index.ts
@@ -1,5 +1,5 @@
-export { Attachments } from "./Attachments";
 export { AttachmentPoints } from "./AttachmentPoints";
+export { Attachments } from "./Attachments";
 export { BlendEquation, BlendFunc, BlendState } from "./BlendState";
 export { Buffer } from "./Buffer";
 export { BufferAccessor as VertexAttribute } from "./BufferAccessor";

--- a/src/renderers/webgl2/shaders/includes/materials/output_flags.glsl.ts
+++ b/src/renderers/webgl2/shaders/includes/materials/output_flags.glsl.ts
@@ -1,8 +1,8 @@
 import { MaterialOutputs } from "../../../../../materials/MaterialOutputs";
 
 function createEnumDefines(): string {
-  let output = [];
-  for (let name in Object.keys(MaterialOutputs)) {
+  const output = [];
+  for (const name in Object.keys(MaterialOutputs)) {
     output.push(`#define MATERIAL_OUTPUTS ${MaterialOutputs[name]}`);
   }
   return output.join("\n");

--- a/src/renderers/webgl2/tasks/ClearTask.ts
+++ b/src/renderers/webgl2/tasks/ClearTask.ts
@@ -5,10 +5,10 @@
 // * @bhouston
 //
 
-import { Attachments } from "../Attachments";
 import { Color } from "../../../math/Color";
-import { ITask } from "./ITask";
+import { Attachments } from "../Attachments";
 import { RenderingContext } from "../RenderingContext";
+import { ITask } from "./ITask";
 
 export class ClearTask implements ITask {
   color: Color = new Color();

--- a/src/renderers/webgl2/tasks/DrawTask.ts
+++ b/src/renderers/webgl2/tasks/DrawTask.ts
@@ -5,11 +5,11 @@
 // * @bhouston
 //
 
-import { ITask } from "./ITask";
 import { PrimitiveType } from "../PrimitiveType";
 import { Program } from "../Program";
 import { RenderingContext } from "../RenderingContext";
 import { VertexArrayObject } from "../VertexArrayObject";
+import { ITask } from "./ITask";
 
 export class DrawTask implements ITask {
   constructor(

--- a/src/renderers/webgl2/tasks/TaskEngine.ts
+++ b/src/renderers/webgl2/tasks/TaskEngine.ts
@@ -1,7 +1,7 @@
-import { Node, depthFirstVisitor } from "../../../nodes/Node";
-import { ITask } from "./ITask";
 import { Mesh } from "../../../nodes/Mesh";
+import { depthFirstVisitor, Node } from "../../../nodes/Node";
 import { RenderingContext } from "../RenderingContext";
+import { ITask } from "./ITask";
 
 export class TaskEngine {
   constructor(public context: RenderingContext) {}

--- a/src/textures/Texture.ts
+++ b/src/textures/Texture.ts
@@ -5,14 +5,14 @@
 // * @bhouston
 //
 
+import { generateUUID } from "../core/generateUuid";
 import { IDisposable, IIdentifiable, IVersionable } from "../core/types";
-import { DataType } from "./DataType";
+import { Vector2 } from "../math/Vector2";
 import { IPoolUser } from "../renderers/Pool";
+import { DataType } from "./DataType";
 import { PixelFormat } from "./PixelFormat";
 import { TextureFilter } from "./TextureFilter";
 import { TextureWrap } from "./TextureWrap";
-import { Vector2 } from "../math/Vector2";
-import { generateUUID } from "../core/generateUuid";
 
 export class ArrayBufferImage {
   constructor(public data: ArrayBuffer, public width: number, public height: number) {}

--- a/src/textures/TextureAccessor.ts
+++ b/src/textures/TextureAccessor.ts
@@ -1,7 +1,7 @@
 import { ICloneable, ICopyable, IVersionable } from "../core/types";
 import { Matrix3 } from "../math/Matrix3";
-import { Texture } from "./Texture";
 import { Vector2 } from "../math/Vector2";
+import { Texture } from "./Texture";
 
 export class TextureAccessor implements ICloneable<TextureAccessor>, ICopyable<TextureAccessor>, IVersionable {
   version = 0;

--- a/threeify.code-workspace
+++ b/threeify.code-workspace
@@ -1,6 +1,5 @@
 {
-  "folders": [
-    {
+  "folders": [{
       "path": "./"
     },
     {
@@ -25,7 +24,8 @@
     "editor.formatOnSave": true,
     "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": true,
+      "source.organizeImports": true
     },
     "editor.wordWrap": "wordWrapColumn",
     "editor.wordWrapColumn": 120,
@@ -34,31 +34,31 @@
       "node_modules/": true
     },
     "cSpell.words": [
-        "Arrayable",
-        "Clearcoat",
-        "Cloneable",
-        "Hashable",
-        "Metalness",
-        "Mipmaps",
-        "Threeify",
-        "Unprojection",
-        "Versionable",
-        "bhouston",
-        "bitmask",
-        "cflint",
-        "cloc",
-        "destructured",
-        "exocortex",
-        "framebuffer",
-        "glsl",
-        "highp",
-        "renderable",
-        "slerp",
-        "threeifydev",
-        "transpiler",
-        "varyings",
-        "webgl",
-        "webgpu"
+      "Arrayable",
+      "Clearcoat",
+      "Cloneable",
+      "Hashable",
+      "Metalness",
+      "Mipmaps",
+      "Threeify",
+      "Unprojection",
+      "Versionable",
+      "bhouston",
+      "bitmask",
+      "cflint",
+      "cloc",
+      "destructured",
+      "exocortex",
+      "framebuffer",
+      "glsl",
+      "highp",
+      "renderable",
+      "slerp",
+      "threeifydev",
+      "transpiler",
+      "varyings",
+      "webgl",
+      "webgpu"
     ]
   }
 }


### PR DESCRIPTION
It is too tedious to sort imports manually with ESLint, so this PR suggests silencing ESLint in favour of the built-in VSCode import sorting suggested by @bhouston in https://github.com/bhouston/threeify/pull/21#issuecomment-641983752, implemented on save now.