### PR TITLE
Fix the linter action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           node-version: "12.13.0"
       - run: npm i -g yarn
+      - run: yarn
       - run: yarn lint

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ import {
   VertexArrayObject,
   VertexAttributeGeometry,
 } from "./renderers/webgl2";
-import debug_fragment from "./shaders/materials/debug/fragment.glsl";
-import debug_vertex from "./shaders/materials/debug/vertex.glsl";
+import debug_fragment from "./shaders/materials/pbr/fragment.glsl";
+import debug_vertex from "./shaders/materials/pbr/vertex.glsl";
 import { Texture, TextureAccessor } from "./textures";
 
 async function test(): Promise<void> {


### PR DESCRIPTION
- First I broke the CI in the last PR introducing yarn.

- Also 2 imports were not updated in a recent commit to master (`src/materials/default/*.glsl` were deleted in https://github.com/bhouston/threeify/commit/3de55b7569653a513043207f04b26b2f173186fc. Here they are updated in `index.ts` with the pbr shaders

It would be nice to protect the master branch from pushing commits at all, so that everything goes into the PR and CI process.