### PR TITLE
 feat: use module facades in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ This library is currently in alpha and in midst of significant development. It m
 This code creates a scene, a camera, and a geometric cube, and it adds the cube to the scene. It then creates a `WebGL` renderer context for the scene and camera, and it adds that viewport to the `document.body` element. Finally, it animates the cube within the scene for the camera.
 
 ```typescript
-import { box } from "./geometry/primitives/Box";
-import { MaterialOutputs } from "./materials/MaterialOutputs";
-import { PhysicalMaterial } from "./materials/PhysicalMaterial";
-import { PerspectiveCamera } from "./nodes/cameras/PerspectiveCamera";
-import { Mesh } from "./nodes/Mesh";
-import { Node } from "./nodes/Node";
-import { RenderingContext } from "./renderers/webgl2";
+import { box } from "@threeify/geometry/primitives/Box";
+import { MaterialOutputs } from "@threeify/materials/MaterialOutputs";
+import { PhysicalMaterial } from "@threeify/materials/PhysicalMaterial";
+import { PerspectiveCamera } from "@threeify/nodes/cameras/PerspectiveCamera";
+import { Mesh } from "@threeify/nodes/Mesh";
+import { Node } from "@threeify/nodes/Node";
+import { RenderingContext } from "@threeify/renderers/webgl2";
 
 const camera = new PerspectiveCamera(70, 0.01, 10);
 camera.position.x = 1;
@@ -48,7 +48,7 @@ const context = new RenderingContext();
 const canvasFramebuffer = context.canvasFramebuffer;
 document.body.appendChild(canvasFramebuffer.canvas);
 
-function animate() {
+function animate(): void {
   requestAnimationFrame(animate);
 
   mesh.rotation.x += 0.01;

--- a/src/examples/gettingstarted/beginnings/threeify_gettingstarted.ts
+++ b/src/examples/gettingstarted/beginnings/threeify_gettingstarted.ts
@@ -1,4 +1,3 @@
-// TODO: figure out a way to get rid of the long "@threeify" from the includes
 import { box } from "@threeify/geometry/primitives/Box";
 import { MaterialOutputs } from "@threeify/materials/MaterialOutputs";
 import { PhysicalMaterial } from "@threeify/materials/PhysicalMaterial";

--- a/src/examples/gettingstarted/beginnings/threeify_gettingstarted.ts
+++ b/src/examples/gettingstarted/beginnings/threeify_gettingstarted.ts
@@ -1,11 +1,11 @@
-// TODO: figure out a way to get rid of the long "../../../lib" from the includes
-import { box } from "../../../lib/geometry/primitives/Box";
-import { MaterialOutputs } from "../../../lib/materials/MaterialOutputs";
-import { PhysicalMaterial } from "../../../lib/materials/PhysicalMaterial";
-import { PerspectiveCamera } from "../../../lib/nodes/cameras/PerspectiveCamera";
-import { Mesh } from "../../../lib/nodes/Mesh";
-import { Node } from "../../../lib/nodes/Node";
-import { RenderingContext } from "../../../lib/renderers/webgl2";
+// TODO: figure out a way to get rid of the long "@threeify" from the includes
+import { box } from "@threeify/geometry/primitives/Box";
+import { MaterialOutputs } from "@threeify/materials/MaterialOutputs";
+import { PhysicalMaterial } from "@threeify/materials/PhysicalMaterial";
+import { PerspectiveCamera } from "@threeify/nodes/cameras/PerspectiveCamera";
+import { Mesh } from "@threeify/nodes/Mesh";
+import { Node } from "@threeify/nodes/Node";
+import { RenderingContext } from "@threeify/renderers/webgl2";
 
 const camera = new PerspectiveCamera(70, 0.01, 10);
 camera.position.x = 1;

--- a/src/examples/testing/testrig1/index.ts
+++ b/src/examples/testing/testrig1/index.ts
@@ -1,4 +1,3 @@
-// TODO: figure out a way to get rid of the long "@threeify" from the includes
 import { box } from "@threeify/geometry/primitives/Box";
 import { fetchImage } from "@threeify/io/loaders/Image";
 import { PhysicalMaterial } from "@threeify/materials/PhysicalMaterial";

--- a/src/examples/testing/testrig1/index.ts
+++ b/src/examples/testing/testrig1/index.ts
@@ -1,13 +1,13 @@
-// TODO: figure out a way to get rid of the long "../../../lib" from the includes
-import { box } from "../../../lib/geometry/primitives/Box";
-import { fetchImage } from "../../../lib/io/loaders/Image";
-import { PhysicalMaterial } from "../../../lib/materials/PhysicalMaterial";
-import { ShaderMaterial } from "../../../lib/materials/ShaderMaterial";
-import { Color } from "../../../lib/math/Color";
-import { PerspectiveCamera } from "../../../lib/nodes/cameras/PerspectiveCamera";
-import { PointLight } from "../../../lib/nodes/lights/PointLight";
-import { Mesh } from "../../../lib/nodes/Mesh";
-import { Node } from "../../../lib/nodes/Node";
+// TODO: figure out a way to get rid of the long "@threeify" from the includes
+import { box } from "@threeify/geometry/primitives/Box";
+import { fetchImage } from "@threeify/io/loaders/Image";
+import { PhysicalMaterial } from "@threeify/materials/PhysicalMaterial";
+import { ShaderMaterial } from "@threeify/materials/ShaderMaterial";
+import { Color } from "@threeify/math/Color";
+import { PerspectiveCamera } from "@threeify/nodes/cameras/PerspectiveCamera";
+import { PointLight } from "@threeify/nodes/lights/PointLight";
+import { Mesh } from "@threeify/nodes/Mesh";
+import { Node } from "@threeify/nodes/Node";
 import {
   Attachments,
   BlendState,
@@ -19,10 +19,10 @@ import {
   TexImage2D,
   VertexArrayObject,
   VertexAttributeGeometry as BufferGeometry,
-} from "../../../lib/renderers/webgl2";
-import debug_fragment from "../../../lib/shaders/materials/pbr/fragment.glsl";
-import debug_vertex from "../../../lib/shaders/materials/pbr/vertex.glsl";
-import { Texture, TextureAccessor } from "../../../lib/textures";
+} from "@threeify/renderers/webgl2";
+import debug_fragment from "@threeify/shaders/materials/pbr/fragment.glsl";
+import debug_vertex from "@threeify/shaders/materials/pbr/vertex.glsl";
+import { Texture, TextureAccessor } from "@threeify/textures";
 
 async function test(): Promise<void> {
   // setup webgl2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,13 +6,18 @@
     "sourceMap": true,
     "declarationMap": true,
     "outDir": "./dist",
+    "baseUrl": "./src",
     "rootDir": "./src",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "*": ["*"],
+      "@threeify/*": ["lib/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": []


### PR DESCRIPTION
here is a quick and dirty method of pretending we have modules.  I just messed with the tsconfig.json based on this Stackoverflow answer:

https://stackoverflow.com/questions/43281741/how-to-use-paths-in-tsconfig-json

@Astrak should we adopt this now?  We could actual modularize our code base via this approach in almost no time.  And then formally adopt modules in the future.