### PR TITLE
chore: replace all non WebgL null usage with undefined

### DIFF
--- a/src/lib/core/Dictionary.ts
+++ b/src/lib/core/Dictionary.ts
@@ -19,12 +19,12 @@ export class Dictionary<K, V> {
     return this.entries.find((item) => item.key === key) !== undefined;
   }
 
-  get(key: K): V | null {
+  get(key: K): V | undefined {
     const entry = this.entries.find((item) => item.key === key);
     if (entry !== undefined) {
       return entry.value;
     }
-    return null;
+    return undefined;
   }
 
   set(key: K, value: V): void {

--- a/src/lib/geometry/Geometry.ts
+++ b/src/lib/geometry/Geometry.ts
@@ -13,7 +13,7 @@ import { AttributeAccessor } from "./AttributeAccessor";
 export class Geometry implements IVersionable, IDisposable {
   disposed = false;
   version = 0;
-  indices: AttributeAccessor | null = null;
+  indices: AttributeAccessor | undefined = undefined;
   attributeAccessors = new Dictionary<string, AttributeAccessor>();
   primitive: PrimitiveType = PrimitiveType.Triangles;
 

--- a/src/lib/math/Box2.ts
+++ b/src/lib/math/Box2.ts
@@ -12,11 +12,11 @@ export class Box2 implements ICloneable<Box2>, IEquatable<Box2>, IHashable {
   min: Vector2 = new Vector2(+Infinity, +Infinity);
   max: Vector2 = new Vector2(-Infinity, -Infinity);
 
-  constructor(min: Vector2 | null = null, max: Vector2 | null = null) {
-    if (min !== null) {
+  constructor(min: Vector2 | undefined = undefined, max: Vector2 | undefined = undefined) {
+    if (min !== undefined) {
       this.min.copy(min);
     }
-    if (max !== null) {
+    if (max !== undefined) {
       this.max.copy(max);
     }
   }

--- a/src/lib/nodes/Node.ts
+++ b/src/lib/nodes/Node.ts
@@ -17,7 +17,7 @@ export class Node implements IIdentifiable, IVersionable, IDisposable {
   disposed = false;
   readonly uuid: string = generateUUID();
   version = 0;
-  parent: Node | null = null;
+  parent: Node | undefined = undefined;
   name = "";
   children: NodeCollection;
   position: Vector3 = new Vector3();
@@ -76,13 +76,13 @@ export function depthFirstVisitor(node: Node, callback: (node: Node) => void): v
 
 export function rootLastVisitor(node: Node, callback: (node: Node) => void): void {
   callback(node);
-  if (node.parent !== null) {
+  if (node.parent !== undefined) {
     rootLastVisitor(node.parent, callback);
   }
 }
 
 export function rootFirstVisitor(node: Node, callback: (node: Node) => void): void {
-  if (node.parent !== null) {
+  if (node.parent !== undefined) {
     rootFirstVisitor(node.parent, callback);
   }
   callback(node);

--- a/src/lib/nodes/NodeCollection.ts
+++ b/src/lib/nodes/NodeCollection.ts
@@ -15,7 +15,7 @@ export class NodeCollection {
     const index = this.array.findIndex((n) => n.uuid === node.uuid);
     if (index >= 0) {
       this.array.splice(index, 1);
-      node.parent = null;
+      node.parent = undefined;
     }
     return this;
   }

--- a/src/lib/renderers/Pool.ts
+++ b/src/lib/renderers/Pool.ts
@@ -10,7 +10,7 @@ import { RenderingContext } from "./webgl2/RenderingContext";
 
 export interface IPoolUser extends IIdentifiable, IVersionable, IDisposable {}
 
-export type UserResourceUpdater<U, R> = (context: RenderingContext, user: U, resource: R | null) => R;
+export type UserResourceUpdater<U, R> = (context: RenderingContext, user: U, resource: R | undefined) => R;
 
 class UserResource<U extends IPoolUser, R extends IDisposable> {
   resourceVersion = -1;
@@ -42,7 +42,7 @@ export class Pool<U extends IPoolUser, R extends IDisposable> {
   request(user: U): UserResource<U, R> {
     let userResource = this.userResources.find((userResource) => userResource.user.uuid === user.uuid);
     if (userResource === undefined) {
-      userResource = new UserResource(user, this.updater(this.context, user, null));
+      userResource = new UserResource(user, this.updater(this.context, user, undefined));
       this.userResources.push(userResource);
     }
 

--- a/src/lib/renderers/webgl2/RenderingContext.ts
+++ b/src/lib/renderers/webgl2/RenderingContext.ts
@@ -28,7 +28,7 @@ export class RenderingContext {
   readonly programPool: ProgramPool;
   readonly bufferPool: BufferPool;
 
-  #program: Program | null = null;
+  #program: Program | undefined = undefined;
   #framebuffer: VirtualFramebuffer;
   #scissor: Box2 = new Box2();
   #viewport: Box2 = new Box2();
@@ -37,8 +37,8 @@ export class RenderingContext {
   #clearState: ClearState = new ClearState();
   #maskState: MaskState = new MaskState();
 
-  constructor(canvas: HTMLCanvasElement | null = null) {
-    if (canvas === null) {
+  constructor(canvas: HTMLCanvasElement | undefined = undefined) {
+    if (canvas === undefined) {
       canvas = document.createElementNS("http://www.w3.org/1999/xhtml", "canvas") as HTMLCanvasElement;
       canvas.style.width = "100%";
       canvas.style.height = "100%";
@@ -58,9 +58,9 @@ export class RenderingContext {
     this.#framebuffer = this.canvasFramebuffer;
   }
 
-  set program(program: Program | null) {
+  set program(program: Program | undefined) {
     if (this.#program !== program) {
-      if (program !== null) {
+      if (program !== undefined) {
         this.gl.useProgram(program.glProgram);
       } else {
         this.gl.useProgram(null);
@@ -68,7 +68,7 @@ export class RenderingContext {
       this.#program = program;
     }
   }
-  get program(): Program | null {
+  get program(): Program | undefined {
     return this.#program;
   }
 

--- a/src/lib/renderers/webgl2/VertexArrayObject.ts
+++ b/src/lib/renderers/webgl2/VertexArrayObject.ts
@@ -35,7 +35,7 @@ export class VertexArrayObject {
 
     bufferGeometry.bufferAccessors.forEach((bufferAccessor, name) => {
       const attribute = this.program.attributes.get(name);
-      if (attribute === null) {
+      if (attribute === undefined) {
         // only bind the attributes that exist in the program.
         return;
       }

--- a/src/lib/renderers/webgl2/buffers/Buffer.ts
+++ b/src/lib/renderers/webgl2/buffers/Buffer.ts
@@ -60,8 +60,8 @@ export class Buffer implements IDisposable {
 
 export class BufferPool extends Pool<Attribute, Buffer> {
   constructor(context: RenderingContext) {
-    super(context, (context: RenderingContext, attribute: Attribute, buffer: Buffer | null) => {
-      if (buffer === null) {
+    super(context, (context: RenderingContext, attribute: Attribute, buffer: Buffer | undefined) => {
+      if (buffer === undefined) {
         return new Buffer(context, attribute.arrayBuffer, attribute.target);
       }
       buffer.update(attribute.arrayBuffer, attribute.target);

--- a/src/lib/renderers/webgl2/buffers/BufferGeometry.ts
+++ b/src/lib/renderers/webgl2/buffers/BufferGeometry.ts
@@ -14,13 +14,13 @@ import { PrimitiveType } from "./PrimitiveType";
 
 export class BufferGeometry {
   bufferAccessors = new Dictionary<string, BufferAccessor>();
-  indices: BufferAccessor | null = null;
+  indices: BufferAccessor | undefined = undefined;
   primitive: PrimitiveType = PrimitiveType.Triangles;
   count = -1;
 
   static FromAttributeGeometry(context: RenderingContext, geometry: Geometry): BufferGeometry {
     const bufferGeometry = new BufferGeometry();
-    if (geometry.indices !== null) {
+    if (geometry.indices !== undefined) {
       bufferGeometry.setIndices(BufferAccessor.FromAttributeAccessor(context, geometry.indices));
       bufferGeometry.count = geometry.indices.count;
     }

--- a/src/lib/renderers/webgl2/framebuffers/VirtualFramebuffer.ts
+++ b/src/lib/renderers/webgl2/framebuffers/VirtualFramebuffer.ts
@@ -39,9 +39,9 @@ export abstract class VirtualFramebuffer implements IDisposable {
 
   clear(
     attachmentFlags: Attachments = Attachments.Color | Attachments.Depth,
-    clearState: ClearState | null = null,
+    clearState: ClearState | undefined = undefined,
   ): void {
-    if (clearState !== null) {
+    if (clearState !== undefined) {
       this.context.clearState = clearState;
     } else {
       this.context.clearState = this.clearState;

--- a/src/lib/renderers/webgl2/programs/Program.ts
+++ b/src/lib/renderers/webgl2/programs/Program.ts
@@ -75,15 +75,15 @@ export class Program implements IDisposable {
     }
   }
 
-  setUniformValues(uniformValues: any, uniformNames: string[] | null = null): void {
+  setUniformValues(uniformValues: any, uniformNames: string[] | undefined = undefined): void {
     this.context.program = this;
-    if (uniformNames === null) {
+    if (uniformNames === undefined) {
       uniformNames = Object.keys(uniformValues) as string[];
     }
     uniformNames.forEach((uniformName) => {
       // TODO replace this.uniforms with a map for faster access
       const uniform = this.uniforms.get(uniformName);
-      if (uniform !== null) {
+      if (uniform !== undefined) {
         uniform.set(uniformValues[uniformName]);
       }
     });
@@ -102,8 +102,8 @@ export class Program implements IDisposable {
 
 export class ProgramPool extends Pool<ShaderMaterial, Program> {
   constructor(context: RenderingContext) {
-    super(context, (context: RenderingContext, shaderCodeMaterial: ShaderMaterial, program: Program | null) => {
-      if (program !== null) {
+    super(context, (context: RenderingContext, shaderCodeMaterial: ShaderMaterial, program: Program | undefined) => {
+      if (program !== undefined) {
         program.dispose();
       }
       return new Program(context, shaderCodeMaterial);

--- a/src/lib/renderers/webgl2/textures/TexImage2D.ts
+++ b/src/lib/renderers/webgl2/textures/TexImage2D.ts
@@ -114,8 +114,8 @@ export class TexImage2D implements IDisposable {
 
 export class TexImage2DPool extends Pool<Texture, TexImage2D> {
   constructor(context: RenderingContext) {
-    super(context, (context: RenderingContext, texture: Texture, texImage2D: TexImage2D | null) => {
-      if (texImage2D === null) {
+    super(context, (context: RenderingContext, texture: Texture, texImage2D: TexImage2D | undefined) => {
+      if (texImage2D === undefined) {
         texImage2D = new TexImage2D(context, texture.image);
       }
       // TODO: Create a new image here.

--- a/src/lib/textures/TextureAccessor.ts
+++ b/src/lib/textures/TextureAccessor.ts
@@ -9,7 +9,7 @@ export class TextureAccessor implements ICloneable<TextureAccessor>, ICopyable<T
   #uvTransformVersion = -1;
 
   constructor(
-    public texture: Texture | null = null,
+    public texture: Texture | undefined = undefined,
     public uvIndex = 0,
     public uvScale: Vector2 = new Vector2(1, 1),
     public uvRotation = 0,


### PR DESCRIPTION
Standardize on undefined for library usage.  Only use null when it is required by WebGL APIs.