### PR TITLE
Decouple webgl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ src/lib/renderers/webgl2/webgl2_fundamentals.js
 
 examples/gettingstarted/threejs_gettingstarted.js
 src/learning_ts.ts
+bundle*.js
+bundle*.js.zip

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "postinstall": "cp --remove-destination ./hooks/prepare-commit-msg ./.git/hooks/prepare-commit-msg && chmod +x ./.git/hooks/prepare-commit-msg"
   },
   "dependencies": {
-    "@webgpu/glslang": "^0.0.15"
+    "@webgpu/glslang": "^0.0.15",
+    "terser": "^4.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
@@ -51,6 +52,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "jest": "^26.0.1",
     "prettier": "^2.0.5",
+    "rollup": "^2.18.0",
     "semantic-release": "^17.0.8",
     "threeify-glsl-transpiler": "0.1.2",
     "ts-jest": "^26.1.0",

--- a/src/examples/gettingstarted/1_triangle/index.ts
+++ b/src/examples/gettingstarted/1_triangle/index.ts
@@ -1,8 +1,8 @@
 import { makeFloat32Attribute, makeUint8Attribute } from "../../../lib/geometry/Attribute";
 import { Geometry } from "../../../lib/geometry/Geometry";
 import { ShaderMaterial } from "../../../lib/materials/ShaderMaterial";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import fragmentSourceCode from "./fragment.glsl";
 import vertexSourceCode from "./vertex.glsl";
@@ -17,8 +17,8 @@ const context = new RenderingContext();
 const canvasFramebuffer = context.canvasFramebuffer;
 document.body.appendChild(canvasFramebuffer.canvas);
 
-const bufferGeometry = new BufferGeometry(context, geometry);
-const program = new Program(context, material);
+const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
+const program = makeProgramFromShaderMaterial(context, material);
 const uniforms = {};
 
 canvasFramebuffer.renderBufferGeometry(program, uniforms, bufferGeometry);

--- a/src/examples/gettingstarted/2_animatedUniforms/index.ts
+++ b/src/examples/gettingstarted/2_animatedUniforms/index.ts
@@ -3,8 +3,8 @@ import { Geometry } from "../../../lib/geometry/Geometry";
 import { ShaderMaterial } from "../../../lib/materials/ShaderMaterial";
 import { Color } from "../../../lib/math/Color";
 import { makeColorFromHSL } from "../../../lib/math/Color.Functions";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import fragmentSourceCode from "./fragment.glsl";
 import vertexSourceCode from "./vertex.glsl";
@@ -19,8 +19,8 @@ const context = new RenderingContext();
 const canvasFramebuffer = context.canvasFramebuffer;
 document.body.appendChild(canvasFramebuffer.canvas);
 
-const bufferGeometry = new BufferGeometry(context, geometry);
-const program = new Program(context, material);
+const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
+const program = makeProgramFromShaderMaterial(context, material);
 const uniforms = { scale: 1.0, color: new Color() };
 
 function animate(): void {

--- a/src/examples/gettingstarted/3_texturedPlane/index.ts
+++ b/src/examples/gettingstarted/3_texturedPlane/index.ts
@@ -1,8 +1,8 @@
 import { plane } from "../../../lib/geometry/primitives/Plane";
 import { fetchImage } from "../../../lib/io/loaders/Image";
 import { ShaderMaterial } from "../../../lib/materials/ShaderMaterial";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import { TexImage2D } from "../../../lib/renderers/webgl2/textures/TexImage2D";
 import { Texture } from "../../../lib/textures/Texture";
@@ -18,8 +18,8 @@ async function init(): Promise<null> {
   const canvasFramebuffer = context.canvasFramebuffer;
   document.body.appendChild(canvasFramebuffer.canvas);
 
-  const bufferGeometry = new BufferGeometry(context, geometry);
-  const program = new Program(context, material);
+  const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
+  const program = makeProgramFromShaderMaterial(context, material);
   const uniforms = { map: new TexImage2D(context, texture) };
 
   canvasFramebuffer.renderBufferGeometry(program, uniforms, bufferGeometry);

--- a/src/examples/gettingstarted/4_lambertCube/index.ts
+++ b/src/examples/gettingstarted/4_lambertCube/index.ts
@@ -9,9 +9,9 @@ import {
   makeMatrix4Translation,
 } from "../../../lib/math/Matrix4.Functions";
 import { Vector3 } from "../../../lib/math/Vector3";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
 import { DepthTestFunc, DepthTestState } from "../../../lib/renderers/webgl2/DepthTestState";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import { TexImage2D } from "../../../lib/renderers/webgl2/textures/TexImage2D";
 import { Texture } from "../../../lib/textures/Texture";
@@ -27,7 +27,7 @@ async function init(): Promise<null> {
   const canvasFramebuffer = context.canvasFramebuffer;
   document.body.appendChild(canvasFramebuffer.canvas);
 
-  const program = new Program(context, material);
+  const program = makeProgramFromShaderMaterial(context, material);
   const uniforms = {
     localToWorld: new Matrix4(),
     worldToView: makeMatrix4Translation(new Matrix4(), new Vector3(0, 0, -1)),
@@ -35,7 +35,7 @@ async function init(): Promise<null> {
     viewLightPosition: new Vector3(0, 0, 0),
     map: new TexImage2D(context, texture),
   };
-  const bufferGeometry = new BufferGeometry(context, geometry);
+  const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
   const depthTestState = new DepthTestState(true, DepthTestFunc.Less);
 
   function animate(): void {

--- a/src/examples/gettingstarted/5_reflectivePolyhedral/index.ts
+++ b/src/examples/gettingstarted/5_reflectivePolyhedral/index.ts
@@ -9,9 +9,9 @@ import {
   makeMatrix4Translation,
 } from "../../../lib/math/Matrix4.Functions";
 import { Vector3 } from "../../../lib/math/Vector3";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
 import { DepthTestFunc, DepthTestState } from "../../../lib/renderers/webgl2/DepthTestState";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import { TexImage2D } from "../../../lib/renderers/webgl2/textures/TexImage2D";
 import { CubeTexture } from "../../../lib/textures/CubeTexture";
@@ -34,14 +34,14 @@ async function init(): Promise<null> {
   const canvasFramebuffer = context.canvasFramebuffer;
   document.body.appendChild(canvasFramebuffer.canvas);
 
-  const program = new Program(context, material);
+  const program = makeProgramFromShaderMaterial(context, material);
   const uniforms = {
     localToWorld: new Matrix4(),
     worldToView: makeMatrix4Translation(new Matrix4(), new Vector3(0, 0, -1)),
     viewToScreen: makeMatrix4Perspective(new Matrix4(), -0.25, 0.25, 0.25, -0.25, 0.1, 4.0),
     cubeMap: new TexImage2D(context, cubeTexture),
   };
-  const bufferGeometry = new BufferGeometry(context, geometry);
+  const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
   const depthTestState = new DepthTestState(true, DepthTestFunc.Less);
 
   function animate(): void {

--- a/src/examples/gettingstarted/6_interleavedBuffers/index.ts
+++ b/src/examples/gettingstarted/6_interleavedBuffers/index.ts
@@ -2,8 +2,8 @@ import { makeFloat32Attribute, makeUint8Attribute } from "../../../lib/geometry/
 import { Geometry } from "../../../lib/geometry/Geometry";
 import { convertToInterleavedGeometry } from "../../../lib/geometry/Geometry.Functions";
 import { ShaderMaterial } from "../../../lib/materials/ShaderMaterial";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import fragmentSourceCode from "./fragment.glsl";
 import vertexSourceCode from "./vertex.glsl";
@@ -19,8 +19,8 @@ const context = new RenderingContext();
 const canvasFramebuffer = context.canvasFramebuffer;
 document.body.appendChild(canvasFramebuffer.canvas);
 
-const bufferGeometry = new BufferGeometry(context, geometry);
-const program = new Program(context, material);
+const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
+const program = makeProgramFromShaderMaterial(context, material);
 const uniforms = {};
 
 canvasFramebuffer.renderBufferGeometry(program, uniforms, bufferGeometry);

--- a/src/examples/gettingstarted/7_metallicRoughness/index.ts
+++ b/src/examples/gettingstarted/7_metallicRoughness/index.ts
@@ -10,9 +10,9 @@ import {
   makeMatrix4Translation,
 } from "../../../lib/math/Matrix4.Functions";
 import { Vector3 } from "../../../lib/math/Vector3";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
 import { DepthTestFunc, DepthTestState } from "../../../lib/renderers/webgl2/DepthTestState";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import { TexImage2D } from "../../../lib/renderers/webgl2/textures/TexImage2D";
 import { CubeTexture } from "../../../lib/textures/CubeTexture";
@@ -35,7 +35,7 @@ async function init(): Promise<null> {
   const canvasFramebuffer = context.canvasFramebuffer;
   document.body.appendChild(canvasFramebuffer.canvas);
 
-  const program = new Program(context, material);
+  const program = makeProgramFromShaderMaterial(context, material);
   const uniforms = {
     localToWorld: new Matrix4(),
     worldToView: makeMatrix4Translation(new Matrix4(), new Vector3(0, 0, -1)),
@@ -43,7 +43,7 @@ async function init(): Promise<null> {
     roughnessFactor: 0,
     cubeMap: new TexImage2D(context, cubeTexture),
   };
-  const bufferGeometry = new BufferGeometry(context, geometry);
+  const bufferGeometry = makeBufferGeometryFromGeometry(context, geometry);
   const depthTestState = new DepthTestState(true, DepthTestFunc.Less);
 
   function animate(): void {

--- a/src/examples/testing/testrig1/index.ts
+++ b/src/examples/testing/testrig1/index.ts
@@ -9,12 +9,12 @@ import { PointLight } from "../../../lib/nodes/lights/PointLight";
 import { Mesh } from "../../../lib/nodes/Mesh";
 import { Node } from "../../../lib/nodes/Node";
 import { BlendState } from "../../../lib/renderers/webgl2/BlendState";
-import { BufferGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
+import { makeBufferGeometryFromGeometry } from "../../../lib/renderers/webgl2/buffers/BufferGeometry";
 import { ClearState } from "../../../lib/renderers/webgl2/ClearState";
 import { DepthTestState } from "../../../lib/renderers/webgl2/DepthTestState";
 import { Attachments } from "../../../lib/renderers/webgl2/framebuffers/Attachments";
 import { MaskState } from "../../../lib/renderers/webgl2/MaskState";
-import { Program } from "../../../lib/renderers/webgl2/programs/Program";
+import { makeProgramFromShaderMaterial } from "../../../lib/renderers/webgl2/programs/Program";
 import { RenderingContext } from "../../../lib/renderers/webgl2/RenderingContext";
 import { TexImage2D } from "../../../lib/renderers/webgl2/textures/TexImage2D";
 import { VertexArrayObject } from "../../../lib/renderers/webgl2/VertexArrayObject";
@@ -58,13 +58,13 @@ async function test(): Promise<void> {
   const texImage2D = new TexImage2D(context, texture);
   console.log(texImage2D);
 
-  const boxBufferGeometry = new BufferGeometry(context, mesh.geometry);
+  const boxBufferGeometry = makeBufferGeometryFromGeometry(context, mesh.geometry);
   console.log(boxBufferGeometry);
 
   // source code definition of material
   const shaderCodeMaterial = new ShaderMaterial(debug_vertex, debug_fragment);
   console.log(shaderCodeMaterial);
-  const program = new Program(context, shaderCodeMaterial);
+  const program = makeProgramFromShaderMaterial(context, shaderCodeMaterial);
   console.log(program);
 
   // using uniform set structures

--- a/yarn.lock
+++ b/yarn.lock
@@ -8463,6 +8463,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.18.0.tgz#f03801e5dd01415e5675dcf61c824ea493ca0392"
+  integrity sha512-LhuQQp3WpnHo3HlKCRrdMXpB6jdLsGOoXXSfMjbv74s5VdV3WZhkYJT0Z6w/EH3UgPH+g/S9T4GJrKW/5iD8TA==
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 rollup@^2.7.2:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.15.0.tgz#1324633188c7f82138bd3bdc99416009ee541f48"
@@ -9248,6 +9255,15 @@ terser@^4.6.7:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
   integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
+  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
This decouples the webgl classes from the CPU-based data model classes.  This helps with tree shaking while also keepign the webgl classes will defined and simple.