### PR TITLE
chore: simplify GL declaration to minimize bundle size.

### DIFF
--- a/src/lib/math/Color.ts
+++ b/src/lib/math/Color.ts
@@ -18,13 +18,15 @@ export class Color implements IPrimitive<Color> {
   clone(): Color {
     return new Color().copy(this);
   }
+  set(r: number, g: number, b: number): this {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+    return this;
+  }
 
   copy(c: Color): this {
-    this.r = c.r;
-    this.g = c.g;
-    this.b = c.b;
-
-    return this;
+    return this.set(c.r, c.g, c.b);
   }
 
   add(c: Color): this {
@@ -44,31 +46,26 @@ export class Color implements IPrimitive<Color> {
   }
 
   getComponent(index: number): number {
-    switch (index) {
-      case 0:
-        return this.r;
-      case 1:
-        return this.g;
-      case 2:
-        return this.b;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      return this.r;
+    } else if (index === 1) {
+      return this.g;
+    } else if (index === 2) {
+      return this.b;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
   }
 
   setComponent(index: number, value: number): this {
-    switch (index) {
-      case 0:
-        this.r = value;
-        break;
-      case 1:
-        this.g = value;
-        break;
-      case 2:
-        this.b = value;
-        break;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      this.r = value;
+    } else if (index === 1) {
+      this.g = value;
+    } else if (index === 2) {
+      this.b = value;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
 
     return this;
@@ -86,15 +83,15 @@ export class Color implements IPrimitive<Color> {
     return c.r === this.r && c.g === this.g && c.b === this.b;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
-    this.r = floatArray[offset + 0];
-    this.g = floatArray[offset + 1];
-    this.b = floatArray[offset + 2];
+  setFromArray(array: Float32Array, offset: number): void {
+    this.r = array[offset + 0];
+    this.g = array[offset + 1];
+    this.b = array[offset + 2];
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
-    floatArray[offset + 0] = this.r;
-    floatArray[offset + 1] = this.g;
-    floatArray[offset + 2] = this.b;
+  toArray(array: Float32Array, offset: number): void {
+    array[offset + 0] = this.r;
+    array[offset + 1] = this.g;
+    array[offset + 2] = this.b;
   }
 }

--- a/src/lib/math/Euler.ts
+++ b/src/lib/math/Euler.ts
@@ -32,29 +32,24 @@ export class Euler implements IPrimitive<Euler> {
   }
 
   copy(e: Euler): this {
-    this.x = e.x;
-    this.y = e.y;
-    this.z = e.z;
-    this.order = e.order;
-
-    return this;
+    return this.set(e.x, e.y, e.z, e.order);
   }
 
   equals(e: Euler): boolean {
     return e.x === this.x && e.y === this.y && e.z === this.z && e.order === this.order;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
-    this.x = floatArray[offset + 0];
-    this.y = floatArray[offset + 1];
-    this.z = floatArray[offset + 2];
-    this.order = floatArray[offset + 3] as EulerOrder;
+  setFromArray(array: Float32Array, offset: number): void {
+    this.x = array[offset + 0];
+    this.y = array[offset + 1];
+    this.z = array[offset + 2];
+    this.order = array[offset + 3] as EulerOrder;
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
-    floatArray[offset + 0] = this.x;
-    floatArray[offset + 1] = this.y;
-    floatArray[offset + 2] = this.z;
-    floatArray[offset + 3] = this.order as number;
+  toArray(array: Float32Array, offset: number): void {
+    array[offset + 0] = this.x;
+    array[offset + 1] = this.y;
+    array[offset + 2] = this.z;
+    array[offset + 3] = this.order as number;
   }
 }

--- a/src/lib/math/Matrix4.ts
+++ b/src/lib/math/Matrix4.ts
@@ -60,28 +60,25 @@ export class Matrix4 implements IPrimitive<Matrix4> {
   }
 
   copy(m: Matrix4): this {
-    const te = this.elements;
     const me = m.elements;
-
-    // TODO: Replace with set(...)
-    te[0] = me[0];
-    te[1] = me[1];
-    te[2] = me[2];
-    te[3] = me[3];
-    te[4] = me[4];
-    te[5] = me[5];
-    te[6] = me[6];
-    te[7] = me[7];
-    te[8] = me[8];
-    te[9] = me[9];
-    te[10] = me[10];
-    te[11] = me[11];
-    te[12] = me[12];
-    te[13] = me[13];
-    te[14] = me[14];
-    te[15] = me[15];
-
-    return this;
+    return this.set(
+      me[0],
+      me[4],
+      me[8],
+      me[12],
+      me[1],
+      me[5],
+      me[9],
+      me[13],
+      me[2],
+      me[6],
+      me[10],
+      me[14],
+      me[3],
+      me[7],
+      me[11],
+      me[15],
+    );
   }
 
   getComponent(index: number): number {
@@ -92,10 +89,6 @@ export class Matrix4 implements IPrimitive<Matrix4> {
     this.elements[index] = value;
 
     return this;
-  }
-
-  numComponents(): 16 {
-    return 16;
   }
 
   multiplyByScalar(s: number): this {
@@ -319,9 +312,7 @@ export class Matrix4 implements IPrimitive<Matrix4> {
   }
 
   makeIdentity(): this {
-    this.set(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
-
-    return this;
+    return this.set(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
   }
 
   equals(m: Matrix4): boolean {
@@ -334,15 +325,15 @@ export class Matrix4 implements IPrimitive<Matrix4> {
     return true;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
+  setFromArray(array: Float32Array, offset: number): void {
     for (let i = 0; i < this.elements.length; i++) {
-      this.elements[i] = floatArray[offset + i];
+      this.elements[i] = array[offset + i];
     }
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
+  toArray(array: Float32Array, offset: number): void {
     for (let i = 0; i < this.elements.length; i++) {
-      floatArray[offset + i] = this.elements[i];
+      array[offset + i] = this.elements[i];
     }
   }
 }

--- a/src/lib/math/Vector2.ts
+++ b/src/lib/math/Vector2.ts
@@ -6,6 +6,7 @@
 //
 
 import { hashFloat2 } from "../core/hash";
+import { clamp } from "./Functions";
 import { IPrimitive } from "./IPrimitive";
 
 export class Vector2 implements IPrimitive<Vector2> {
@@ -41,10 +42,7 @@ export class Vector2 implements IPrimitive<Vector2> {
   }
 
   copy(v: Vector2): this {
-    this.x = v.x;
-    this.y = v.y;
-
-    return this;
+    return this.set(v.x, v.y);
   }
 
   add(v: Vector2): this {
@@ -88,33 +86,25 @@ export class Vector2 implements IPrimitive<Vector2> {
   }
 
   getComponent(index: number): number {
-    switch (index) {
-      case 0:
-        return this.x;
-      case 1:
-        return this.y;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      return this.x;
+    } else if (index === 1) {
+      return this.y;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
   }
 
   setComponent(index: number, value: number): this {
-    switch (index) {
-      case 0:
-        this.x = value;
-        break;
-      case 1:
-        this.y = value;
-        break;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      this.x = value;
+    } else if (index === 1) {
+      this.y = value;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
 
     return this;
-  }
-
-  numComponents(): 2 {
-    return 2;
   }
 
   dot(v: Vector2): number {
@@ -144,10 +134,8 @@ export class Vector2 implements IPrimitive<Vector2> {
   }
 
   clamp(min: Vector2, max: Vector2): this {
-    // assumes min < max, componentwise
-
-    this.x = Math.max(min.x, Math.min(max.x, this.x));
-    this.y = Math.max(min.y, Math.min(max.y, this.y));
+    this.x = clamp(this.x, min.x, max.x);
+    this.y = clamp(this.y, min.y, max.y);
 
     return this;
   }
@@ -156,13 +144,13 @@ export class Vector2 implements IPrimitive<Vector2> {
     return v.x === this.x && v.y === this.y;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
-    this.x = floatArray[offset + 0];
-    this.y = floatArray[offset + 1];
+  setFromArray(array: Float32Array, offset: number): void {
+    this.x = array[offset + 0];
+    this.y = array[offset + 1];
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
-    floatArray[offset + 0] = this.x;
-    floatArray[offset + 1] = this.y;
+  toArray(array: Float32Array, offset: number): void {
+    array[offset + 0] = this.x;
+    array[offset + 1] = this.y;
   }
 }

--- a/src/lib/math/Vector3.ts
+++ b/src/lib/math/Vector3.ts
@@ -6,6 +6,7 @@
 //
 
 import { hashFloat3 } from "../core/hash";
+import { clamp } from "./Functions";
 import { IPrimitive } from "./IPrimitive";
 
 export class Vector3 implements IPrimitive<Vector3> {
@@ -49,11 +50,7 @@ export class Vector3 implements IPrimitive<Vector3> {
   }
 
   copy(v: Vector3): this {
-    this.x = v.x;
-    this.y = v.y;
-    this.z = v.z;
-
-    return this;
+    return this.set(v.x, v.y, v.z);
   }
 
   add(v: Vector3): this {
@@ -110,38 +107,29 @@ export class Vector3 implements IPrimitive<Vector3> {
   }
 
   getComponent(index: number): number {
-    switch (index) {
-      case 0:
-        return this.x;
-      case 1:
-        return this.y;
-      case 2:
-        return this.z;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      return this.x;
+    } else if (index === 1) {
+      return this.y;
+    } else if (index === 2) {
+      return this.z;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
   }
 
   setComponent(index: number, value: number): this {
-    switch (index) {
-      case 0:
-        this.x = value;
-        break;
-      case 1:
-        this.y = value;
-        break;
-      case 2:
-        this.z = value;
-        break;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      this.x = value;
+    } else if (index === 1) {
+      this.y = value;
+    } else if (index === 2) {
+      this.z = value;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
 
     return this;
-  }
-
-  numComponents(): 3 {
-    return 3;
   }
 
   dot(v: Vector3): number {
@@ -199,11 +187,9 @@ export class Vector3 implements IPrimitive<Vector3> {
   }
 
   clamp(min: Vector3, max: Vector3): this {
-    // assumes min < max, componentwise
-
-    this.x = Math.max(min.x, Math.min(max.x, this.x));
-    this.y = Math.max(min.y, Math.min(max.y, this.y));
-    this.z = Math.max(min.z, Math.min(max.z, this.z));
+    this.x = clamp(this.x, min.x, max.x);
+    this.y = clamp(this.y, min.y, max.y);
+    this.z = clamp(this.z, min.z, max.z);
 
     return this;
   }
@@ -212,15 +198,15 @@ export class Vector3 implements IPrimitive<Vector3> {
     return v.x === this.x && v.y === this.y && v.z === this.z;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
-    this.x = floatArray[offset + 0];
-    this.y = floatArray[offset + 1];
-    this.z = floatArray[offset + 2];
+  setFromArray(array: Float32Array, offset: number): void {
+    this.x = array[offset + 0];
+    this.y = array[offset + 1];
+    this.z = array[offset + 2];
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
-    floatArray[offset + 0] = this.x;
-    floatArray[offset + 1] = this.y;
-    floatArray[offset + 2] = this.z;
+  toArray(array: Float32Array, offset: number): void {
+    array[offset + 0] = this.x;
+    array[offset + 1] = this.y;
+    array[offset + 2] = this.z;
   }
 }

--- a/src/lib/math/Vector4.ts
+++ b/src/lib/math/Vector4.ts
@@ -29,12 +29,7 @@ export class Vector4 implements IPrimitive<Vector4> {
   }
 
   copy(v: Vector4): this {
-    this.x = v.x;
-    this.y = v.y;
-    this.z = v.z;
-    this.w = v.w;
-
-    return this;
+    return this.set(v.x, v.y, v.z, v.w);
   }
 
   add(v: Vector4): this {
@@ -79,43 +74,33 @@ export class Vector4 implements IPrimitive<Vector4> {
   }
 
   getComponent(index: number): number {
-    switch (index) {
-      case 0:
-        return this.x;
-      case 1:
-        return this.y;
-      case 2:
-        return this.z;
-      case 3:
-        return this.w;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      return this.x;
+    } else if (index === 1) {
+      return this.y;
+    } else if (index === 2) {
+      return this.z;
+    } else if (index === 3) {
+      return this.w;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
   }
 
   setComponent(index: number, value: number): this {
-    switch (index) {
-      case 0:
-        this.x = value;
-        break;
-      case 1:
-        this.y = value;
-        break;
-      case 2:
-        this.z = value;
-        break;
-      case 3:
-        this.w = value;
-        break;
-      default:
-        throw new Error(`index of our range: ${index}`);
+    if (index === 0) {
+      this.x = value;
+    } else if (index === 1) {
+      this.y = value;
+    } else if (index === 2) {
+      this.z = value;
+    } else if (index === 3) {
+      this.w = value;
+    } else {
+      throw new Error(`index of our range: ${index}`);
     }
 
     return this;
-  }
-
-  numComponents(): 4 {
-    return 4;
   }
 
   dot(v: Vector4): number {
@@ -134,17 +119,17 @@ export class Vector4 implements IPrimitive<Vector4> {
     return v.x === this.x && v.y === this.y && v.z === this.z && v.w === this.w;
   }
 
-  setFromArray(floatArray: Float32Array, offset: number): void {
-    this.x = floatArray[offset + 0];
-    this.y = floatArray[offset + 1];
-    this.z = floatArray[offset + 2];
-    this.w = floatArray[offset + 3];
+  setFromArray(array: Float32Array, offset: number): void {
+    this.x = array[offset + 0];
+    this.y = array[offset + 1];
+    this.z = array[offset + 2];
+    this.w = array[offset + 3];
   }
 
-  toArray(floatArray: Float32Array, offset: number): void {
-    floatArray[offset + 0] = this.x;
-    floatArray[offset + 1] = this.y;
-    floatArray[offset + 2] = this.z;
-    floatArray[offset + 3] = this.w;
+  toArray(array: Float32Array, offset: number): void {
+    array[offset + 0] = this.x;
+    array[offset + 1] = this.y;
+    array[offset + 2] = this.z;
+    array[offset + 3] = this.w;
   }
 }

--- a/src/lib/renderers/webgl2/BlendState.ts
+++ b/src/lib/renderers/webgl2/BlendState.ts
@@ -7,8 +7,7 @@
 
 import { ICloneable, IEquatable } from "../../core/types";
 import { Blending } from "../../materials/Blending";
-
-const GL = WebGLRenderingContext;
+import { GL } from "./GL";
 
 export enum BlendEquation {
   /**

--- a/src/lib/renderers/webgl2/DepthTestState.ts
+++ b/src/lib/renderers/webgl2/DepthTestState.ts
@@ -6,8 +6,7 @@
 //
 
 import { ICloneable, IEquatable } from "../../core/types";
-
-const GL = WebGLRenderingContext;
+import { GL } from "./GL";
 
 export enum DepthTestFunc {
   /**

--- a/src/lib/renderers/webgl2/GL.ts
+++ b/src/lib/renderers/webgl2/GL.ts
@@ -1,0 +1,1 @@
+export const GL = WebGLRenderingContext;

--- a/src/lib/renderers/webgl2/RenderingContext.ts
+++ b/src/lib/renderers/webgl2/RenderingContext.ts
@@ -9,24 +9,21 @@ import { Box2 } from "../../math/Box2";
 import { Camera } from "../../nodes/cameras/Camera";
 import { Node } from "../../nodes/Node";
 import { BlendState } from "./BlendState";
-import { BufferPool } from "./buffers/Buffer";
 import { ClearState } from "./ClearState";
 import { DepthTestState } from "./DepthTestState";
 import { CanvasFramebuffer } from "./framebuffers/CanvasFramebuffer";
 import { Framebuffer } from "./framebuffers/Framebuffer";
 import { VirtualFramebuffer } from "./framebuffers/VirtualFramebuffer";
+import { GL } from "./GL";
 import { MaskState } from "./MaskState";
-import { Program, ProgramPool } from "./programs/Program";
-import { TexImage2DPool } from "./textures/TexImage2D";
-
-const GL = WebGLRenderingContext;
+import { Program } from "./programs/Program";
 
 export class RenderingContext {
   readonly gl: WebGL2RenderingContext;
   readonly canvasFramebuffer: CanvasFramebuffer;
-  readonly texImage2DPool: TexImage2DPool;
-  readonly programPool: ProgramPool;
-  readonly bufferPool: BufferPool;
+  // readonly texImage2DPool: TexImage2DPool;
+  // readonly programPool: ProgramPool;
+  // readonly bufferPool: BufferPool;
 
   #program: Program | undefined = undefined;
   #framebuffer: VirtualFramebuffer;
@@ -55,9 +52,9 @@ export class RenderingContext {
       this.gl = gl;
     }
     this.canvasFramebuffer = new CanvasFramebuffer(this, canvas);
-    this.texImage2DPool = new TexImage2DPool(this);
-    this.programPool = new ProgramPool(this);
-    this.bufferPool = new BufferPool(this);
+    // this.texImage2DPool = new TexImage2DPool(this);
+    // this.programPool = new ProgramPool(this);
+    // this.bufferPool = new BufferPool(this);
     this.#framebuffer = this.canvasFramebuffer;
   }
 
@@ -78,9 +75,9 @@ export class RenderingContext {
   set framebuffer(framebuffer: VirtualFramebuffer) {
     if (this.#framebuffer !== framebuffer) {
       if (framebuffer instanceof CanvasFramebuffer) {
-        this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+        this.gl.bindFramebuffer(GL.FRAMEBUFFER, null);
       } else if (framebuffer instanceof Framebuffer) {
-        this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, framebuffer.glFramebuffer);
+        this.gl.bindFramebuffer(GL.FRAMEBUFFER, framebuffer.glFramebuffer);
       }
       this.#framebuffer = framebuffer;
     }

--- a/src/lib/renderers/webgl2/buffers/BufferTarget.ts
+++ b/src/lib/renderers/webgl2/buffers/BufferTarget.ts
@@ -5,8 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
-const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 export enum BufferTarget {
   /**
@@ -21,25 +20,25 @@ export enum BufferTarget {
   /**
    * Buffer for copying from one buffer object to another.
    */
-  CopyRead = GL2.COPY_READ_BUFFER,
+  // CopyRead = GL2.COPY_READ_BUFFER,
   /**
    * Buffer for copying from one buffer object to another.
    */
-  CopyWrite = GL2.COPY_WRITE_BUFFER,
+  // CopyWrite = GL2.COPY_WRITE_BUFFER,
   /**
    * Buffer for transform feedback operations.
    */
-  TransformFeedback = GL2.TRANSFORM_FEEDBACK_BUFFER,
+  // TransformFeedback = GL2.TRANSFORM_FEEDBACK_BUFFER,
   /**
    * Buffer used for storing uniform blocks.
    */
-  Uniform = GL2.UNIFORM_BUFFER,
+  // Uniform = GL2.UNIFORM_BUFFER,
   /**
    * Buffer used for pixel transfer operations.
    */
-  PixelPack = GL2.PIXEL_PACK_BUFFER,
+  // PixelPack = GL2.PIXEL_PACK_BUFFER,
   /**
    * Buffer used for pixel transfer operations.
    */
-  PixelUnpack = GL2.PIXEL_UNPACK_BUFFER,
+  // PixelUnpack = GL2.PIXEL_UNPACK_BUFFER,
 }

--- a/src/lib/renderers/webgl2/buffers/BufferUsage.ts
+++ b/src/lib/renderers/webgl2/buffers/BufferUsage.ts
@@ -1,5 +1,4 @@
-const GL = WebGLRenderingContext;
-const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 export enum BufferUsage {
   /**
@@ -19,38 +18,38 @@ export enum BufferUsage {
    * used at most a few times as the source for WebGL drawing and image
    * specification commands.
    */
-  StreamDraw = GL2.STREAM_DRAW,
+  // StreamDraw = GL2.STREAM_DRAW,
   /**
    * The contents are intended to be specified once by reading data from WebGL,
    * and queried many times by the application.
    */
-  StaticRead = GL2.STATIC_READ,
+  // StaticRead = GL2.STATIC_READ,
   /**
    * The contents are intended to be re-specified repeatedly by reading data
    * from WebGL, and queried many times by the application.
    */
-  DynamicRead = GL2.DYNAMIC_READ,
+  // DynamicRead = GL2.DYNAMIC_READ,
   /**
    * The contents are intended to be specified once by reading data from WebGL,
    * and queried at most a few times by the application
    */
-  StreamRead = GL2.STREAM_READ,
+  // StreamRead = GL2.STREAM_READ,
   /**
    * The contents are intended to be specified once by reading data from WebGL,
    * and used many times as the source for WebGL drawing and image
    * specification commands.
    */
-  StaticCopy = GL2.STATIC_COPY,
+  // StaticCopy = GL2.STATIC_COPY,
   /**
    * The contents are intended to be re-specified repeatedly by reading data
    * from WebGL, and used many times as the source for WebGL drawing and image
    * specification commands.
    */
-  DynamicCopy = GL2.DYNAMIC_COPY,
+  // DynamicCopy = GL2.DYNAMIC_COPY,
   /**
    * The contents are intended to be specified once by reading data from WebGL,
    * and used at most a few times as the source for WebGL drawing and image
    * specification commands.
    */
-  StreamCopy = GL2.STREAM_COPY,
+  // StreamCopy = GL2.STREAM_COPY,
 }

--- a/src/lib/renderers/webgl2/buffers/ComponentType.ts
+++ b/src/lib/renderers/webgl2/buffers/ComponentType.ts
@@ -5,8 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
-const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 export enum ComponentType {
   /**
@@ -40,7 +39,7 @@ export enum ComponentType {
   /**
    * 16-bit IEEE floating point number
    */
-  HalfFloat = GL2.HALF_FLOAT,
+  // HalfFloat = GL2.HALF_FLOAT,
 }
 
 export function componentTypeSizeOf(componentType: ComponentType): number {
@@ -48,7 +47,7 @@ export function componentTypeSizeOf(componentType: ComponentType): number {
     case ComponentType.Byte:
     case ComponentType.UnsignedByte:
       return 1;
-    case ComponentType.HalfFloat:
+    // case ComponentType.HalfFloat:
     case ComponentType.Short:
     case ComponentType.UnsignedShort:
       return 2;

--- a/src/lib/renderers/webgl2/buffers/PrimitiveType.ts
+++ b/src/lib/renderers/webgl2/buffers/PrimitiveType.ts
@@ -1,4 +1,4 @@
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum PrimitiveType {
   Points = GL.POINTS,

--- a/src/lib/renderers/webgl2/framebuffers/AttachmentPoints.ts
+++ b/src/lib/renderers/webgl2/framebuffers/AttachmentPoints.ts
@@ -1,4 +1,4 @@
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum AttachmentPoints {
   Color0 = GL.COLOR_ATTACHMENT0,

--- a/src/lib/renderers/webgl2/framebuffers/Attachments.ts
+++ b/src/lib/renderers/webgl2/framebuffers/Attachments.ts
@@ -1,4 +1,4 @@
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum Attachments {
   Color = GL.COLOR_BUFFER_BIT,

--- a/src/lib/renderers/webgl2/programs/ProgramUniform.ts
+++ b/src/lib/renderers/webgl2/programs/ProgramUniform.ts
@@ -2,12 +2,11 @@ import { Color } from "../../../math/Color";
 import { Matrix4 } from "../../../math/Matrix4";
 import { Vector2 } from "../../../math/Vector2";
 import { Vector3 } from "../../../math/Vector3";
+import { GL } from "../GL";
 import { RenderingContext } from "../RenderingContext";
 import { TexImage2D } from "../textures/TexImage2D";
 import { Program } from "./Program";
 import { UniformType } from "./UniformType";
-
-export const GL2 = WebGL2RenderingContext;
 
 export type UniformValue = number | Vector2 | Vector3 | Color | Matrix4 | TexImage2D;
 export type UniformValueMap = { [key: string]: UniformValue };
@@ -122,21 +121,21 @@ export class ProgramUniform {
         }
         break;
       case UniformType.Sampler2D:
-      case UniformType.IntSampler2D:
-      case UniformType.UnsignedIntSampler2D:
-      case UniformType.Sampler2DShadow:
+        // case UniformType.IntSampler2D:
+        // case UniformType.UnsignedIntSampler2D:
+        // case UniformType.Sampler2DShadow:
         if (value instanceof TexImage2D) {
-          gl.activeTexture(GL2.TEXTURE0 + this.textureUnit);
-          gl.bindTexture(GL2.TEXTURE_2D, value.glTexture);
+          gl.activeTexture(GL.TEXTURE0 + this.textureUnit);
+          gl.bindTexture(GL.TEXTURE_2D, value.glTexture);
           gl.uniform1i(this.glLocation, this.textureUnit);
           return this;
         }
         break;
       case UniformType.SamplerCube:
-      case UniformType.SamplerCubeShadow:
+        // case UniformType.SamplerCubeShadow:
         if (value instanceof TexImage2D) {
-          gl.activeTexture(GL2.TEXTURE0 + this.textureUnit);
-          gl.bindTexture(GL2.TEXTURE_CUBE_MAP, value.glTexture);
+          gl.activeTexture(GL.TEXTURE0 + this.textureUnit);
+          gl.bindTexture(GL.TEXTURE_CUBE_MAP, value.glTexture);
           gl.uniform1i(this.glLocation, this.textureUnit);
           return this;
         }

--- a/src/lib/renderers/webgl2/programs/UniformType.ts
+++ b/src/lib/renderers/webgl2/programs/UniformType.ts
@@ -1,72 +1,72 @@
-export const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 export enum UniformType {
-  Bool = GL2.BOOL,
-  BoolVec2 = GL2.BOOL_VEC2,
-  BoolVec3 = GL2.BOOL_VEC3,
-  BoolVec4 = GL2.BOOL_VEC4,
-  Int = GL2.INT,
-  IntVec2 = GL2.INT_VEC2,
-  IntVec3 = GL2.INT_VEC3,
-  IntVec4 = GL2.INT_VEC4,
-  Float = GL2.FLOAT,
-  FloatVec2 = GL2.FLOAT_VEC2,
-  FloatVec3 = GL2.FLOAT_VEC3,
-  FloatVec4 = GL2.FLOAT_VEC4,
-  FloatMat2 = GL2.FLOAT_MAT2,
-  FloatMat2x3 = GL2.FLOAT_MAT2x3,
-  FloatMat2x4 = GL2.FLOAT_MAT2x4,
-  FloatMat3x2 = GL2.FLOAT_MAT3x2,
-  FloatMat3 = GL2.FLOAT_MAT3,
-  FloatMat3x4 = GL2.FLOAT_MAT3x4,
-  FloatMat4x2 = GL2.FLOAT_MAT4x3,
-  FloatMat4x3 = GL2.FLOAT_MAT4x3,
-  FloatMat4 = GL2.FLOAT_MAT4,
+  Bool = GL.BOOL,
+  BoolVec2 = GL.BOOL_VEC2,
+  BoolVec3 = GL.BOOL_VEC3,
+  BoolVec4 = GL.BOOL_VEC4,
+  Int = GL.INT,
+  IntVec2 = GL.INT_VEC2,
+  IntVec3 = GL.INT_VEC3,
+  IntVec4 = GL.INT_VEC4,
+  Float = GL.FLOAT,
+  FloatVec2 = GL.FLOAT_VEC2,
+  FloatVec3 = GL.FLOAT_VEC3,
+  FloatVec4 = GL.FLOAT_VEC4,
+  FloatMat2 = GL.FLOAT_MAT2,
+  // FloatMat2x3 = GL2.FLOAT_MAT2x3,
+  // FloatMat2x4 = GL2.FLOAT_MAT2x4,
+  // FloatMat3x2 = GL2.FLOAT_MAT3x2,
+  FloatMat3 = GL.FLOAT_MAT3,
+  // FloatMat3x4 = GL2.FLOAT_MAT3x4,
+  // FloatMat4x2 = GL2.FLOAT_MAT4x3,
+  // FloatMat4x3 = GL2.FLOAT_MAT4x3,
+  FloatMat4 = GL.FLOAT_MAT4,
   // setValueT1;
-  Sampler2D = GL2.SAMPLER_2D,
-  IntSampler2D = GL2.INT_SAMPLER_2D,
-  UnsignedIntSampler2D = GL2.UNSIGNED_INT_SAMPLER_2D,
-  Sampler2DShadow = GL2.SAMPLER_2D_SHADOW,
+  Sampler2D = GL.SAMPLER_2D,
+  // IntSampler2D = GL2.INT_SAMPLER_2D,
+  // UnsignedIntSampler2D = GL2.UNSIGNED_INT_SAMPLER_2D,
+  // Sampler2DShadow = GL2.SAMPLER_2D_SHADOW,
   // setValueT3D1;
-  Sampler3D = GL2.SAMPLER_3D,
-  IntSampler3D = GL2.INT_SAMPLER_3D,
-  UnsignedIntSampler3D = GL2.UNSIGNED_INT_SAMPLER_3D,
+  // Sampler3D = GL2.SAMPLER_3D,
+  // IntSampler3D = GL2.INT_SAMPLER_3D,
+  // UnsignedIntSampler3D = GL2.UNSIGNED_INT_SAMPLER_3D,
   // setValueT6
-  SamplerCube = GL2.SAMPLER_CUBE,
-  IntSamplerCube = GL2.INT_SAMPLER_CUBE,
-  UnsignedIntSamplerCube = GL2.UNSIGNED_INT_SAMPLER_CUBE,
-  SamplerCubeShadow = GL2.SAMPLER_CUBE_SHADOW,
+  SamplerCube = GL.SAMPLER_CUBE,
+  // IntSamplerCube = GL2.INT_SAMPLER_CUBE,
+  // UnsignedIntSamplerCube = GL2.UNSIGNED_INT_SAMPLER_CUBE,
+  // SamplerCubeShadow = GL2.SAMPLER_CUBE_SHADOW,
   // setValueT2DArray1
-  Sampler2DArray = GL2.SAMPLER_2D_ARRAY,
-  IntSampler2DArray = GL2.INT_SAMPLER_2D_ARRAY,
-  UnsignedIntSampler2DArray = GL2.UNSIGNED_INT_SAMPLER_2D_ARRAY,
-  Sampler2DArrayShadow = GL2.SAMPLER_2D_ARRAY_SHADOW,
+  // Sampler2DArray = GL2.SAMPLER_2D_ARRAY,
+  // IntSampler2DArray = GL2.INT_SAMPLER_2D_ARRAY,
+  // UnsignedIntSampler2DArray = GL2.UNSIGNED_INT_SAMPLER_2D_ARRAY,
+  // Sampler2DArrayShadow = GL2.SAMPLER_2D_ARRAY_SHADOW,
 }
 
 export function numTextureUnits(uniformType: UniformType): number {
   switch (uniformType) {
     case UniformType.Sampler2D:
-    case UniformType.IntSampler2D:
-    case UniformType.UnsignedIntSampler2D:
-    case UniformType.Sampler2DShadow:
+      // case UniformType.IntSampler2D:
+      // case UniformType.UnsignedIntSampler2D:
+      // case UniformType.Sampler2DShadow:
       return 1;
 
-    case UniformType.Sampler3D:
-    case UniformType.IntSampler3D:
-    case UniformType.UnsignedIntSampler3D:
-      return 1;
+    // case UniformType.Sampler3D:
+    // case UniformType.IntSampler3D:
+    // case UniformType.UnsignedIntSampler3D:
+    //  return 1;
 
     case UniformType.SamplerCube:
-    case UniformType.IntSamplerCube:
-    case UniformType.UnsignedIntSamplerCube:
-    case UniformType.SamplerCubeShadow:
+      // case UniformType.IntSamplerCube:
+      // case UniformType.UnsignedIntSamplerCube:
+      // case UniformType.SamplerCubeShadow:
       return 1; // cube textures only take one slot
 
-    case UniformType.Sampler2DArray:
-    case UniformType.IntSampler2DArray:
-    case UniformType.UnsignedIntSampler2DArray:
-    case UniformType.Sampler2DArrayShadow:
-      return 1;
+    // case UniformType.Sampler2DArray:
+    // case UniformType.IntSampler2DArray:
+    // case UniformType.UnsignedIntSampler2DArray:
+    // case UniformType.Sampler2DArrayShadow:
+    //  return 1;
 
     default:
       return 0;

--- a/src/lib/renderers/webgl2/shaders/ShaderType.ts
+++ b/src/lib/renderers/webgl2/shaders/ShaderType.ts
@@ -5,7 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum ShaderType {
   Fragment = GL.FRAGMENT_SHADER,

--- a/src/lib/renderers/webgl2/textures/DataType.ts
+++ b/src/lib/renderers/webgl2/textures/DataType.ts
@@ -5,18 +5,17 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
-const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 // from https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D
 export enum DataType {
-  Byte = GL2.BYTE,
+  Byte = GL.BYTE,
   UnsignedByte = GL.UNSIGNED_BYTE,
-  Short = GL2.SHORT,
+  Short = GL.SHORT,
   UnsignedShort = GL.UNSIGNED_SHORT,
-  Int = GL2.INT,
+  Int = GL.INT,
   UnsignedInt = GL.UNSIGNED_INT,
-  HalfFloat = GL2.HALF_FLOAT,
+  // HalfFloat = GL.HALF_FLOAT,
   Float = GL.FLOAT,
 }
 
@@ -27,7 +26,7 @@ export function sizeOfDataType(dataType: DataType): number {
       return 1;
     case DataType.Short:
     case DataType.UnsignedShort:
-    case DataType.HalfFloat:
+      // case DataType.HalfFloat:
       return 2;
     case DataType.Int:
     case DataType.UnsignedInt:

--- a/src/lib/renderers/webgl2/textures/PixelFormat.ts
+++ b/src/lib/renderers/webgl2/textures/PixelFormat.ts
@@ -5,8 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
-const GL2 = WebGL2RenderingContext;
+import { GL } from "../GL";
 
 // from https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D
 export enum PixelFormat {
@@ -15,8 +14,8 @@ export enum PixelFormat {
   LuminanceAlpha = GL.LUMINANCE_ALPHA,
   Luminance = GL.LUMINANCE,
   Alpha = GL.ALPHA,
-  DepthComponent = GL2.DEPTH_COMPONENT,
-  DepthStencil = GL2.DEPTH_STENCIL,
+  DepthComponent = GL.DEPTH_COMPONENT,
+  DepthStencil = GL.DEPTH_STENCIL,
 }
 
 export function numPixelFormatComponents(pixelFormat: PixelFormat): number {

--- a/src/lib/renderers/webgl2/textures/TexImage2D.ts
+++ b/src/lib/renderers/webgl2/textures/TexImage2D.ts
@@ -12,13 +12,12 @@ import { ArrayBufferImage } from "../../../textures/ArrayBufferImage";
 import { CubeTexture } from "../../../textures/CubeTexture";
 import { Texture, TextureImage } from "../../../textures/Texture";
 import { Pool } from "../../Pool";
+import { GL } from "../GL";
 import { RenderingContext } from "../RenderingContext";
 import { DataType } from "./DataType";
 import { PixelFormat } from "./PixelFormat";
 import { TexParameters } from "./TexParameters";
 import { TextureTarget } from "./TextureTarget";
-
-export const GL = WebGLRenderingContext;
 
 export class TexImage2D implements IDisposable {
   disposed = false;
@@ -71,11 +70,11 @@ export class TexImage2D implements IDisposable {
       gl.generateMipmap(this.target);
     }
 
-    gl.texParameteri(this.target, gl.TEXTURE_WRAP_S, texParameters.wrapS);
-    gl.texParameteri(this.target, gl.TEXTURE_WRAP_T, texParameters.wrapS);
+    gl.texParameteri(this.target, GL.TEXTURE_WRAP_S, texParameters.wrapS);
+    gl.texParameteri(this.target, GL.TEXTURE_WRAP_T, texParameters.wrapS);
 
-    gl.texParameteri(this.target, gl.TEXTURE_MAG_FILTER, texParameters.magFilter);
-    gl.texParameteri(this.target, gl.TEXTURE_MIN_FILTER, texParameters.minFilter);
+    gl.texParameteri(this.target, GL.TEXTURE_MAG_FILTER, texParameters.magFilter);
+    gl.texParameteri(this.target, GL.TEXTURE_MIN_FILTER, texParameters.minFilter);
 
     gl.bindTexture(this.target, null);
 

--- a/src/lib/renderers/webgl2/textures/TextureFilter.ts
+++ b/src/lib/renderers/webgl2/textures/TextureFilter.ts
@@ -5,7 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum TextureFilter {
   LinearMipmapLinear = GL.LINEAR_MIPMAP_LINEAR,

--- a/src/lib/renderers/webgl2/textures/TextureTarget.ts
+++ b/src/lib/renderers/webgl2/textures/TextureTarget.ts
@@ -1,6 +1,5 @@
-const GL = WebGL2RenderingContext;
+import { GL } from "../GL";
 
-// from https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D
 export enum TextureTarget {
   Texture2D = GL.TEXTURE_2D,
   TextureCubeMap = GL.TEXTURE_CUBE_MAP,

--- a/src/lib/renderers/webgl2/textures/TextureWrap.ts
+++ b/src/lib/renderers/webgl2/textures/TextureWrap.ts
@@ -5,7 +5,7 @@
 // * @bhouston
 //
 
-const GL = WebGLRenderingContext;
+import { GL } from "../GL";
 
 export enum TextureWrap {
   MirroredRepeat = GL.MIRRORED_REPEAT,


### PR DESCRIPTION
change how I was declaring the GL const to minimize bundle size.  Turns out that multiple local const declarations were showing up individually in the bundle, but the strategy employed in this PR simplifies to one single definition that is shared across the whole bundle.  This saves about 1KB.