### PR TITLE
Use min version for node dependency instead of fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^3.9.3"
   },
   "engines": {
-    "node": "12.13.0"
+    "node": "^12.13.0"
   },
   "engineStrict": true,
   "prettier": {


### PR DESCRIPTION
This change allows yarn install to work if you have a slightly newer version of node installed.