### PR TITLE
fix: work around PNG loading bug on Chrome?

### DIFF
--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -2,7 +2,7 @@ precision highp float;
 
 uniform sampler2D layerMap;
 uniform float mipmapBias;
-uniform int premultipliedAlpha;
+uniform int convertToPremultipliedAlpha;
 
 uniform vec2 layerUVScale;
 
@@ -22,10 +22,9 @@ void main() {
   vec4 layerColor = texture2D( layerMap, texelUv, mipmapBias );
 
   // premultiply alpha in output as the source PNG is not premultiplied
-  if( premultipliedAlpha == 1 ) {
+  if( convertToPremultipliedAlpha == 1 ) {
     layerColor.rgb *= layerColor.a;
   }
-
   gl_FragColor = layerColor;
 
 }

--- a/src/lib/platform/Detection.ts
+++ b/src/lib/platform/Detection.ts
@@ -1,0 +1,11 @@
+export function isMacOS(): boolean {
+  // source: https://stackoverflow.com/questions/10527983/best-way-to-detect-mac-os-x-or-windows-computers-with-javascript-or-jquery
+  return /(Mac)/i.test(navigator.platform);
+}
+export function isiOS(): boolean {
+  // source: https://stackoverflow.com/questions/10527983/best-way-to-detect-mac-os-x-or-windows-computers-with-javascript-or-jquery
+  return /(iPhone|iPod|iPad)/i.test(navigator.platform);
+}
+export function isFirefox(): boolean {
+  return /(Gecko\/)/i.test(navigator.userAgent);
+}

--- a/src/lib/renderers/webgl/RenderingContext.ts
+++ b/src/lib/renderers/webgl/RenderingContext.ts
@@ -6,9 +6,7 @@
 //
 
 import { Box2 } from "../../math/Box2";
-import { Camera } from "../../nodes/cameras/Camera";
-import { Node } from "../../nodes/Node";
-import { BlendState } from "./BlendState";
+import { BlendEquation, BlendFunc, BlendState } from "./BlendState";
 import { Buffer } from "./buffers/Buffer";
 import { ClearState } from "./ClearState";
 import { CullingState } from "./CullingState";
@@ -22,7 +20,6 @@ import { GL } from "./GL";
 import { MaskState } from "./MaskState";
 import { getParameterAsString } from "./Parameters";
 import { Program } from "./programs/Program";
-import { UniformValueMap } from "./programs/ProgramUniform";
 import { Renderbuffer } from "./Renderbuffer";
 import { Shader } from "./shaders/Shader";
 import { TexImage2D } from "./textures/TexImage2D";
@@ -160,6 +157,11 @@ export class RenderingContext {
       this.gl.enable(GL.BLEND);
       this.gl.blendEquation(bs.equation);
       this.gl.blendFuncSeparate(bs.sourceRGBFactor, bs.destRGBFactor, bs.sourceAlphaFactor, bs.destAlphaFactor);
+      console.log(
+        `Blend ${BlendEquation[bs.equation]} srcRGB ${BlendFunc[bs.sourceRGBFactor]} destRGB ${
+          BlendFunc[bs.destRGBFactor]
+        } srcA ${BlendFunc[bs.sourceAlphaFactor]} destA ${BlendFunc[bs.destAlphaFactor]}`,
+      );
       this.#blendState.copy(bs);
     }
   }
@@ -217,14 +219,5 @@ export class RenderingContext {
       this.gl.cullFace(cs.sides);
       this.#cullingState.copy(cs);
     }
-  }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  renderPass(program: Program, uniforms: UniformValueMap): void {
-    throw new Error("not implemented");
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  render(node: Node, camera: Camera): void {
-    throw new Error("not implemented");
   }
 }

--- a/src/lib/renderers/webgl/framebuffers/VirtualFramebuffer.ts
+++ b/src/lib/renderers/webgl/framebuffers/VirtualFramebuffer.ts
@@ -146,5 +146,6 @@ export function renderPass(
   context.program.setUniformValues(uniforms);
   context.viewport = new Box2(new Vector2(), framebuffer.size);
 
+  throw new Error("Not implemented");
   // context.renderPass(program, uniforms); // just executes a pre-determined node and camera setup.
 }

--- a/src/lib/renderers/webgl/framebuffers/VirtualFramebuffer.ts
+++ b/src/lib/renderers/webgl/framebuffers/VirtualFramebuffer.ts
@@ -54,7 +54,8 @@ export abstract class VirtualFramebuffer implements IDisposable {
     if (clear) {
       this.clear();
     }
-    this.context.render(node, camera);
+    throw new Error("Not implemented");
+    //    this.context.render(node, camera);
   }
 
   flush(): void {
@@ -145,5 +146,5 @@ export function renderPass(
   context.program.setUniformValues(uniforms);
   context.viewport = new Box2(new Vector2(), framebuffer.size);
 
-  context.renderPass(program, uniforms); // just executes a pre-determined node and camera setup.
+  // context.renderPass(program, uniforms); // just executes a pre-determined node and camera setup.
 }


### PR DESCRIPTION
*  does not understand why this is necessary.
* this means it may be working around a bug, and thus this will break in the future.
* the bug would be in chrome as it seems to be the inverse of the current query