### PR TITLE
Layer masking and blending

### DIFF
--- a/src/lib/engines/layerCompositor/LCh.glsl
+++ b/src/lib/engines/layerCompositor/LCh.glsl
@@ -1,0 +1,73 @@
+// According to https://www.w3.org/TR/compositing-1/#blendingnonseparable
+const vec3 lumaCoef = vec3( 0.3, 0.59, 0.11 );
+
+float minComponent( vec3 color ){
+  return min( color.r, min( color.g, color.b ) );
+}
+
+float maxComponent( vec3 color ){
+  return max( color.r, max( color.g, color.b ) );
+}
+
+float getLuma( vec3 color ){
+  return dot( color, lumaCoef );
+}
+
+float getChroma( vec3 color ){
+  return maxComponent( color ) - minComponent( color );
+}
+
+// Sets the Chroma, whilst keeping the Hue, and discarding the Luma
+vec3 withChroma( vec3 color,  float chroma ){
+
+  float min = minComponent( color );
+  float max = maxComponent( color );
+
+  if( min >= max ){
+    // Gray Color
+    return vec3( 0. );
+  }
+
+  float curChroma = getChroma( color );
+
+  vec3 withSat = (color - min) * chroma / curChroma;
+  return withSat;
+}
+
+vec3 withLuma( vec3 color, float luma){
+
+  float curLuma = getLuma(color);
+  float dLuma = luma - curLuma;
+
+  // This works because lumaCoef sums to 1.0
+  vec3 withL = color + dLuma;
+
+  float min = minComponent( withL );
+  float max = maxComponent( withL );
+
+  // In case the color ends up outside the RGB Gamut, re-scale the color to amke it fit.
+  if( min < 0.0 ) {
+    return ( withL - luma ) * luma / ( luma - min ) + luma;
+  } else if ( max > 1.0 ) {
+    return ( withL - luma ) * ( 1.0 - luma ) / ( max - luma ) + luma;
+  } else {
+    return withL;
+  }
+
+}
+
+vec3 mixLCH( vec3 lumaColor, vec3 chromaColor, vec3 hueColor ){
+
+  float targetChroma = getChroma( chromaColor );
+  float targetLuma = getLuma( lumaColor );
+
+  return withLuma( withChroma( hueColor, targetChroma ), targetLuma );
+
+}
+
+vec3 mixLCHFast( vec3 lumaColor, vec3 chromaHueColor ){
+
+  float targetLuma = getLuma( lumaColor );
+  return withLuma( chromaHueColor, targetLuma );
+
+}

--- a/src/lib/engines/layerCompositor/Layer.ts
+++ b/src/lib/engines/layerCompositor/Layer.ts
@@ -7,7 +7,7 @@ import { Vector3 } from "../../math/Vector3";
 import { TexImage2D } from "../../renderers/webgl/textures/TexImage2D";
 import { LayerCompositor } from "./LayerCompositor";
 
-export class Layer {
+class LayerTexture {
   disposed = false;
   planeToImage: Matrix4;
   uvToTexture: Matrix3;
@@ -30,5 +30,41 @@ export class Layer {
     const uvScale = makeMatrix3Scale(this.uvScaleFactor);
     const uvTranslation = makeMatrix3Translation(this.uvOffset);
     this.uvToTexture = makeMatrix3Concatenation(uvTranslation, uvScale);
+  }
+}
+
+export enum LayerMaskMode {
+  None = 0,
+  Alpha = 1,
+  Luminance = 2,
+  InverseAlpha = 3,
+  InverseLuminance = 4,
+}
+
+export class LayerMask extends LayerTexture {
+  constructor(
+    compositor: LayerCompositor,
+    url: string,
+    texImage2D: TexImage2D,
+    offset: Vector2,
+    public mode: LayerMaskMode = LayerMaskMode.Alpha,
+    uvScaleFactor = new Vector2(1, -1),
+    uvOffset = new Vector2(0, 1),
+  ) {
+    super(compositor, url, texImage2D, offset, uvScaleFactor, uvOffset);
+  }
+}
+
+export class Layer extends LayerTexture {
+  constructor(
+    compositor: LayerCompositor,
+    url: string,
+    texImage2D: TexImage2D,
+    offset: Vector2,
+    public mask?: LayerMask,
+    uvScaleFactor = new Vector2(1, -1),
+    uvOffset = new Vector2(0, 1),
+  ) {
+    super(compositor, url, texImage2D, offset, uvScaleFactor, uvOffset);
   }
 }

--- a/src/lib/engines/layerCompositor/Layer.ts
+++ b/src/lib/engines/layerCompositor/Layer.ts
@@ -1,16 +1,20 @@
 import { Matrix3 } from "../../math/Matrix3";
-import { makeMatrix3Concatenation, makeMatrix3Scale, makeMatrix3Translation } from "../../math/Matrix3.Functions";
 import { Matrix4 } from "../../math/Matrix4";
 import { makeMatrix4Concatenation, makeMatrix4Scale, makeMatrix4Translation } from "../../math/Matrix4.Functions";
 import { Vector2 } from "../../math/Vector2";
 import { Vector3 } from "../../math/Vector3";
 import { TexImage2D } from "../../renderers/webgl/textures/TexImage2D";
 import { LayerCompositor } from "./LayerCompositor";
+import { makeMatrix3FromViewToLayerUv } from "./makeMatrix3FromViewToLayerUv";
 
 class LayerTexture {
   disposed = false;
   planeToImage: Matrix4;
-  uvToTexture: Matrix3;
+  viewToLayerUv: Matrix3;
+
+  public get size(): Vector2 {
+    return this.texImage2D.size;
+  }
 
   constructor(
     public compositor: LayerCompositor,
@@ -27,9 +31,7 @@ class LayerTexture {
     const layerToImage = makeMatrix4Translation(new Vector3(this.offset.x, this.offset.y, 0.0));
     this.planeToImage = makeMatrix4Concatenation(layerToImage, planeToLayer);
 
-    const uvScale = makeMatrix3Scale(this.uvScaleFactor);
-    const uvTranslation = makeMatrix3Translation(this.uvOffset);
-    this.uvToTexture = makeMatrix3Concatenation(uvTranslation, uvScale);
+    this.viewToLayerUv = makeMatrix3FromViewToLayerUv(this.size, this.offset, false);
   }
 }
 

--- a/src/lib/engines/layerCompositor/Layer.ts
+++ b/src/lib/engines/layerCompositor/Layer.ts
@@ -41,6 +41,38 @@ export enum LayerMaskMode {
   InverseLuminance = 4,
 }
 
+export enum LayerBlendMode {
+  Clear = 0,
+  Src = 1,
+  Dst = 2,
+  SrcOver = 3,
+  DstOver = 4,
+  SrcIn = 5,
+  DstIn = 6,
+  SrcOut = 7,
+  DstOut = 8,
+  SrcAtop = 9,
+  DstAtop = 10,
+  Xor = 11,
+  Add = 12,
+  Multiply = 13,
+  Screen = 14,
+  Overlay = 15,
+  Lighten = 16,
+  Darken = 17,
+  // Available in canvases, but not implemented.
+  // Dodge = 18,
+  // Burn = 19,
+  // HardLight = 20,
+  // SoftLight = 21,
+  // Difference = 22,
+  // Exclusion = 23,
+  Hue = 24,
+  Saturation = 25,
+  Color = 26,
+  Luminosity = 27,
+}
+
 export class LayerMask extends LayerTexture {
   constructor(
     compositor: LayerCompositor,
@@ -62,6 +94,7 @@ export class Layer extends LayerTexture {
     texImage2D: TexImage2D,
     offset: Vector2,
     public mask?: LayerMask,
+    public blendMode: LayerBlendMode = LayerBlendMode.SrcOver,
     uvScaleFactor = new Vector2(1, -1),
     uvOffset = new Vector2(0, 1),
   ) {

--- a/src/lib/engines/layerCompositor/Layer.ts
+++ b/src/lib/engines/layerCompositor/Layer.ts
@@ -101,7 +101,7 @@ export class LayerMask extends LayerTexture {
     url: string,
     texImage2D: TexImage2D,
     offset: Vector2,
-    public mode: LayerMaskMode = LayerMaskMode.Alpha,
+    public mode: LayerMaskMode = LayerMaskMode.Luminance,
     uvScaleFactor = new Vector2(1, -1),
     uvOffset = new Vector2(0, 1),
   ) {

--- a/src/lib/engines/layerCompositor/LayerCompositor.ts
+++ b/src/lib/engines/layerCompositor/LayerCompositor.ts
@@ -373,7 +373,9 @@ export class LayerCompositor {
     // - does not understand why this is necessary.
     // - this means it may be working around a bug, and thus this will break in the future.
     // - the bug would be in chrome as it seems to be the inverse of the current query
-    const convertToPremultipliedAlpha = !(isMacOS() || isiOS() || isFirefox()) ? 0 : 1;
+    // Antoine on 2022-04-08
+    // - Firefox now also sends premultiplied textures to the shader, which seems to indicate the problem rests with the IOS/Mac implementation
+    const convertToPremultipliedAlpha = isMacOS() || isiOS() ? 1 : 0;
 
     // const offscreenLocalToView = makeMatrix4Scale(new Vector3(this.offscreenSize.x, this.offscreenSize.y, 1.0));
     const viewToImageUv = makeMatrix3FromViewToLayerUv(this.offscreenSize, undefined, true);
@@ -398,7 +400,7 @@ export class LayerCompositor {
           viewToScreen: imageToOffscreen,
 
           mipmapBias: 0,
-          convertToPremultipliedAlpha,
+          convertToPremultipliedAlpha: 0,
 
           imageMap: this.offscreenWriteColorAttachment!, // Not used, but avoids framebuffer loop
           viewToImageUv,
@@ -409,8 +411,6 @@ export class LayerCompositor {
           maskMode: 0,
           blendMode: 0,
         };
-        offscreenReadFramebuffer.clearState = new ClearState(new Vector3(0, 0, 0), 0.0);
-        offscreenReadFramebuffer.clear();
 
         renderBufferGeometry(
           this.offscreenReadFramebuffer!,

--- a/src/lib/engines/layerCompositor/LayerCompositor.ts
+++ b/src/lib/engines/layerCompositor/LayerCompositor.ts
@@ -184,7 +184,7 @@ export class LayerCompositor {
   loadTexImage2D(url: string, image: HTMLImageElement | ImageBitmap | undefined = undefined): Promise<TexImage2D> {
     const layerImagePromise = this.texImage2DPromiseCache[url];
     if (layerImagePromise !== undefined) {
-      console.log(`loading: ${url} (reusing promise)`);
+      // console.log(`loading: ${url} (reusing promise)`);
       return layerImagePromise;
     }
 
@@ -207,7 +207,7 @@ export class LayerCompositor {
         texture.anisotropicLevels = 1;
         texture.name = url;
 
-        console.log(`loading: ${url}`);
+        // console.log(`loading: ${url}`);
         // load texture onto the GPU
         const texImage2D = makeTexImage2DFromTexture(compositor.context, texture);
         delete compositor.texImage2DPromiseCache[url];
@@ -231,7 +231,7 @@ export class LayerCompositor {
     // check for texture in cache.
     const layerImage = this.layerImageCache[url];
     if (layerImage !== undefined) {
-      console.log(`discarding: ${url}`);
+      // console.log(`discarding: ${url}`);
       layerImage.dispose();
       delete this.layerImageCache[url];
       return true;

--- a/src/lib/engines/layerCompositor/blend.frag
+++ b/src/lib/engines/layerCompositor/blend.frag
@@ -5,6 +5,10 @@ vec4 compositeColors(vec4 src, vec4 dst) {
 
   vec3 Sc = src.rgb;
   vec3 Dc = dst.rgb;
+  float Sa = src.a;
+  float ISa = 1.0 - Sa;
+  float Da = dst.a;
+  float IDa = 1.0 - Da;
 
   vec3 blend;
 
@@ -48,11 +52,6 @@ vec4 compositeColors(vec4 src, vec4 dst) {
       else   /* blendMode == 27 */  blend = mixLCHFast( Sc, Dc );
     }
   }
-
-  float Sa = src.a;
-  float ISa = 1.0 - Sa;
-  float Da = dst.a;
-  float IDa = 1.0 - Da;
 
   return vec4(
     IDa * Sc + ISa * Dc + Sa * Da * blend,

--- a/src/lib/engines/layerCompositor/blend.frag
+++ b/src/lib/engines/layerCompositor/blend.frag
@@ -1,8 +1,7 @@
 #pragma include "./LCh.glsl"
 
-uniform int blendMode;
-
-vec4 compositeColors(vec4 src, vec4 dst){
+// See LayerBlendMode in Layer.ts for a list of enum values
+vec4 compositeColors(vec4 src, vec4 dst) {
 
   vec3 Sc = src.rgb;
   vec3 Dc = dst.rgb;
@@ -11,163 +10,52 @@ vec4 compositeColors(vec4 src, vec4 dst){
   float Da = dst.a;
   float IDa = 1.0 - Da;
 
-  // Clear
-  if( blendMode == 0){
-    return vec4(0.);
-  }
-  // Src
-  if( blendMode == 1){
-    return vec4(src);
-  }
-  // Dst
-  if( blendMode == 2){
-    return vec4(dst);
-  }
-  // SrcOver
-  if( blendMode == 3){
-    return vec4(
-      Sc + Dc*ISa,
-      Sa + Da*ISa
-    );
-  }
-  // DstOver
-  if( blendMode == 4){
-    return vec4(
-      Dc + Sc*IDa,
-      Da + Sa*IDa
-    );
-  }
-  // SrcIn
-  if( blendMode == 5){
-    return vec4(
-      Sc*Da,
-      Sa*Da
-    );
-  }
-  // DstIn
-  if( blendMode == 6){
-    return vec4(
-      Dc*Sa,
-      Sa*Da
-    );
-  }
-  // SrcOut
-  if( blendMode == 7){
-    return vec4(
-      Sc*IDa,
-      Sa*IDa
-    );
-  }
-   // DstOut
-  if( blendMode == 8){
-    return vec4(
-      Dc*ISa,
-      Da*ISa
-    );
-  }
-  // SrcAtop
-  if( blendMode == 9 ){
-    return vec4(
-      Sc*Da + Dc*ISa,
-      Da
-    );
-  }
-  // DstAtop
-  if( blendMode == 10 ){
-    return vec4(
-      Dc*Sa + Sc*IDa,
-      Sa
-    );
-  }
-  // Xor
-  if( blendMode == 11 ){
-    return vec4(
-      Sc * IDa + Dc*ISa,
-      Sa * IDa + Da * ISa
-    );
-  }
-  // Add
-  if( blendMode == 12 ){
-    return vec4(
-      Sc+Dc,
-      Sa+Da
-    );
-  }
-  // Multiply (Matching Html Canvas and Photoshop)
-  if( blendMode == 13 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + Sc * Dc,
-      IDa * Sa + ISa * Da + Sa * Da
-    );
-  }
-  // Screen
-  if( blendMode == 14 ){
-    return vec4(
-      1.0 - (1.0 - Sc) * (1.0 - Dc),
-      1.0 - ISa * IDa
-    );
-  }
-  // Overlay
-  if( blendMode == 15 ){
-    vec3 edge = step( Da * 0.5, Dc );
-    vec3 mul = IDa * Sc + ISa * Dc + 2.0 * Sc * Dc;
-    vec3 screen = Sa * Da - 2.0 * (Da - Sc)* (Sa -Dc);
+  vec3 blend;
 
-    return vec4(
-      mix(mul, screen, edge),
-      Sa + Da - Sa * Da
-    );
+  if ( blendMode < 24 ) {
+    if ( blendMode < 16 ) {
+      // Multiply (Matching Html Canvas and Photoshop)
+      if      ( blendMode == 13 )   blend = Sc * Dc;
+
+      // Screen (Matching Html Canvas and Photoshop)
+      else if ( blendMode == 14 )   blend = ( 1.0 - ( ( 1.0 - Sc ) * ( 1.0 - Dc ) ) );
+
+      // Overlay (Matching Html Canvas and Photoshop)
+      else   /* blendMode == 15 */ {
+        vec3 edge = step( Da * 0.5, Dc );
+        vec3 mul = 2.0 * Sc * Dc;
+        vec3 screen = ( 1.0 - 2.0 * ( ( 1.0 - Sc ) * ( 1.0 - Dc ) ) );
+        blend = mix( mul, screen, edge );
+      }
+    }
+    else {
+      // Ligthen
+      if      ( blendMode == 16 )   blend = max(Sc, Dc);
+
+      // Darken
+      else   /* blendMode == 17 */  blend = min(Sc, Dc);
+    }
   }
-  // Ligthen
-  if( blendMode == 16 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + max(Sc, Dc),
-      Sa + ISa * Da
-    );
-  }
-  // Darken
-  if( blendMode == 17 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + min(Sc, Dc),
-      Sa + ISa * Da
-    );
+  else {
+    if ( blendMode < 26 ) {
+      // Hue (Hue from src, Chroma/Luma from dst)
+      if      ( blendMode == 24 )   blend = mixLCH( Sa * Dc, Dc, Sc );
+
+      // Saturation (Chroma from src, Hue/Luma from dst)
+      else   /* blendMode == 25 */  blend = mixLCH( Sa * Dc, Sc, Dc );
+    }
+    else {
+
+      // Color ( Hue/Chroma from src, Luma from dst)
+      if      ( blendMode == 26 )   blend = mixLCHFast( Sa * Dc, Sc );
+
+      // Luminosity ( Luma from src, Hue/Chroma from dst )
+      else   /* blendMode == 27 */  blend = mixLCHFast( Da * Sc, Dc );
+    }
   }
 
-  // Hue (Hue from src, Chroma/Luma from dst)
-  if( blendMode == 24 ){ // Double check with inverse
-    vec3 new = mixLCH( Sa * Dc, Dc, Sc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
+  vec3 remain = IDa * Sc + ISa * Dc;
+  float overA = Sa + ISa * Da;
 
-  // Saturation (Chroma from src, Hue/Luma from dst)
-  if( blendMode == 25 ){
-    vec3 new = mixLCH( Sa * Dc, Sc, Dc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  // Color ( Hue/Chroma from src, Luma from dst)
-  if( blendMode == 26 ){
-    vec3 new = mixLCHFast( Sa * Dc, Sc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  // Luminosity ( Luma from src, Hue/Chroma from dst )
-  if( blendMode == 27 ){
-    vec3 new = mixLCHFast( Da * Sc, Dc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  return vec4(0.);
+  return vec4( remain + blend, overA );
 }

--- a/src/lib/engines/layerCompositor/blend.frag
+++ b/src/lib/engines/layerCompositor/blend.frag
@@ -5,10 +5,6 @@ vec4 compositeColors(vec4 src, vec4 dst) {
 
   vec3 Sc = src.rgb;
   vec3 Dc = dst.rgb;
-  float Sa = src.a;
-  float ISa = 1.0 - Sa;
-  float Da = dst.a;
-  float IDa = 1.0 - Da;
 
   vec3 blend;
 
@@ -18,14 +14,14 @@ vec4 compositeColors(vec4 src, vec4 dst) {
       if      ( blendMode == 13 )   blend = Sc * Dc;
 
       // Screen (Matching Html Canvas and Photoshop)
-      else if ( blendMode == 14 )   blend = ( 1.0 - ( ( 1.0 - Sc ) * ( 1.0 - Dc ) ) );
+      else if ( blendMode == 14 )   blend = 1.0 - ( ( 1.0 - Sc ) * ( 1.0 - Dc ) );
 
       // Overlay (Matching Html Canvas and Photoshop)
       else   /* blendMode == 15 */ {
-        vec3 edge = step( Da * 0.5, Dc );
-        vec3 mul = 2.0 * Sc * Dc;
-        vec3 screen = ( 1.0 - 2.0 * ( ( 1.0 - Sc ) * ( 1.0 - Dc ) ) );
-        blend = mix( mul, screen, edge );
+        vec3 edge = step( 0.5, Dc );
+        vec3 mul = Sc * Dc;
+        vec3 screen = 0.5 - ( ( 1.0 - Sc ) * ( 1.0 - Dc ) );
+        blend =  2.0 * mix( mul, screen, edge );
       }
     }
     else {
@@ -39,23 +35,27 @@ vec4 compositeColors(vec4 src, vec4 dst) {
   else {
     if ( blendMode < 26 ) {
       // Hue (Hue from src, Chroma/Luma from dst)
-      if      ( blendMode == 24 )   blend = mixLCH( Sa * Dc, Dc, Sc );
+      if      ( blendMode == 24 )   blend = mixLCH( Dc, Dc, Sc );
 
       // Saturation (Chroma from src, Hue/Luma from dst)
-      else   /* blendMode == 25 */  blend = mixLCH( Sa * Dc, Sc, Dc );
+      else   /* blendMode == 25 */  blend = mixLCH( Dc, Sc, Dc );
     }
     else {
-
       // Color ( Hue/Chroma from src, Luma from dst)
-      if      ( blendMode == 26 )   blend = mixLCHFast( Sa * Dc, Sc );
+      if      ( blendMode == 26 )   blend = mixLCHFast( Dc, Sc );
 
       // Luminosity ( Luma from src, Hue/Chroma from dst )
-      else   /* blendMode == 27 */  blend = mixLCHFast( Da * Sc, Dc );
+      else   /* blendMode == 27 */  blend = mixLCHFast( Sc, Dc );
     }
   }
 
-  vec3 remain = IDa * Sc + ISa * Dc;
-  float overA = Sa + ISa * Da;
+  float Sa = src.a;
+  float ISa = 1.0 - Sa;
+  float Da = dst.a;
+  float IDa = 1.0 - Da;
 
-  return vec4( remain + blend, overA );
+  return vec4(
+    IDa * Sc + ISa * Dc + Sa * Da * blend,
+    Sa + ISa * Da
+  );
 }

--- a/src/lib/engines/layerCompositor/blend.frag
+++ b/src/lib/engines/layerCompositor/blend.frag
@@ -1,0 +1,173 @@
+#pragma include "./LCh.glsl"
+
+uniform int blendMode;
+
+vec4 compositeColors(vec4 src, vec4 dst){
+
+  vec3 Sc = src.rgb;
+  vec3 Dc = dst.rgb;
+  float Sa = src.a;
+  float ISa = 1.0 - Sa;
+  float Da = dst.a;
+  float IDa = 1.0 - Da;
+
+  // Clear
+  if( blendMode == 0){
+    return vec4(0.);
+  }
+  // Src
+  if( blendMode == 1){
+    return vec4(src);
+  }
+  // Dst
+  if( blendMode == 2){
+    return vec4(dst);
+  }
+  // SrcOver
+  if( blendMode == 3){
+    return vec4(
+      Sc + Dc*ISa,
+      Sa + Da*ISa
+    );
+  }
+  // DstOver
+  if( blendMode == 4){
+    return vec4(
+      Dc + Sc*IDa,
+      Da + Sa*IDa
+    );
+  }
+  // SrcIn
+  if( blendMode == 5){
+    return vec4(
+      Sc*Da,
+      Sa*Da
+    );
+  }
+  // DstIn
+  if( blendMode == 6){
+    return vec4(
+      Dc*Sa,
+      Sa*Da
+    );
+  }
+  // SrcOut
+  if( blendMode == 7){
+    return vec4(
+      Sc*IDa,
+      Sa*IDa
+    );
+  }
+   // DstOut
+  if( blendMode == 8){
+    return vec4(
+      Dc*ISa,
+      Da*ISa
+    );
+  }
+  // SrcAtop
+  if( blendMode == 9 ){
+    return vec4(
+      Sc*Da + Dc*ISa,
+      Da
+    );
+  }
+  // DstAtop
+  if( blendMode == 10 ){
+    return vec4(
+      Dc*Sa + Sc*IDa,
+      Sa
+    );
+  }
+  // Xor
+  if( blendMode == 11 ){
+    return vec4(
+      Sc * IDa + Dc*ISa,
+      Sa * IDa + Da * ISa
+    );
+  }
+  // Add
+  if( blendMode == 12 ){
+    return vec4(
+      Sc+Dc,
+      Sa+Da
+    );
+  }
+  // Multiply (Matching Html Canvas and Photoshop)
+  if( blendMode == 13 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + Sc * Dc,
+      IDa * Sa + ISa * Da + Sa * Da
+    );
+  }
+  // Screen
+  if( blendMode == 14 ){
+    return vec4(
+      1.0 - (1.0 - Sc) * (1.0 - Dc),
+      1.0 - ISa * IDa
+    );
+  }
+  // Overlay
+  if( blendMode == 15 ){
+    vec3 edge = step( Da * 0.5, Dc );
+    vec3 mul = IDa * Sc + ISa * Dc + 2.0 * Sc * Dc;
+    vec3 screen = Sa * Da - 2.0 * (Da - Sc)* (Sa -Dc);
+
+    return vec4(
+      mix(mul, screen, edge),
+      Sa + Da - Sa * Da
+    );
+  }
+  // Ligthen
+  if( blendMode == 16 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + max(Sc, Dc),
+      Sa + ISa * Da
+    );
+  }
+  // Darken
+  if( blendMode == 17 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + min(Sc, Dc),
+      Sa + ISa * Da
+    );
+  }
+
+  // Hue (Hue from src, Chroma/Luma from dst)
+  if( blendMode == 24 ){ // Double check with inverse
+    vec3 new = mixLCH( Sa * Dc, Dc, Sc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Saturation (Chroma from src, Hue/Luma from dst)
+  if( blendMode == 25 ){
+    vec3 new = mixLCH( Sa * Dc, Sc, Dc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Color ( Hue/Chroma from src, Luma from dst)
+  if( blendMode == 26 ){
+    vec3 new = mixLCHFast( Sa * Dc, Sc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Luminosity ( Luma from src, Hue/Chroma from dst )
+  if( blendMode == 27 ){
+    vec3 new = mixLCHFast( Da * Sc, Dc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  return vec4(0.);
+}

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -28,13 +28,22 @@ void main() {
   vec4 outputColor = layerColor;
 
   if( maskMode != 0 ){
-    vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
-    // premultiply alpha as the source PNG is not premultiplied
-    if( convertToPremultipliedAlpha == 1 ) {
-      maskColor.rgb *= maskColor.a;
-    }
 
-    outputColor *= getMaskValue( maskColor );
+    // Check if we're in the [ 0.0, 1.0 ] UV range for masking. Otherwise, we'll get clamping artifacts.
+    vec2 gt0 = step( 0., v_mask_uv );
+    vec2 lt1 = 1.0 - step( 1., v_mask_uv );
+    bool isMasked = dot( gt0, lt1 ) == 2.0;
+
+    if( isMasked ) {
+
+      vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
+      // premultiply alpha as the source PNG is not premultiplied
+      if( convertToPremultipliedAlpha == 1 ) {
+        maskColor.rgb *= maskColor.a;
+      }
+
+      outputColor *= getMaskValue( maskColor );
+    }
   }
 
   if( blendMode != 0){

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -18,36 +18,38 @@ varying vec2 v_uv;
 #pragma include <math/math>
 #pragma include <color/spaces/srgb>
 
+float getMaskValue(){
+
+  if( maskMode == 0 ) return 1.0;
+
+  vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
+  vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
+
+  float maskValue;
+
+  if ( maskMode == 1 ) return maskTexel.a;
+  if ( maskMode == 2 ) return maskTexel.r;
+  if ( maskMode == 3 ) return 1.0 - maskTexel.a;
+  if ( maskMode == 4 ) return 1.0 - maskTexel.r;
+
+  return 1.0;
+
+}
+
 void main() {
   vec3 outputColor = vec3(0.);
   vec2 texelUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
 
   vec4 layerColor = texture2D( layerMap, texelUv, mipmapBias );
 
-  if ( maskMode > 0 ) {
-    
-    vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
-    vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
+  layerColor *= getMaskValue();
 
-    float maskValue;
-
-    if( maskMode == 2 || maskMode == 4 ) {
-      maskValue = maskTexel.r;
-    } else {
-      maskValue = maskTexel.a;
-    }
-
-    if( maskMode >= 3 ) {
-      maskValue = 1.0 - maskValue;
-    }
-
-    layerColor *= maskValue;
-  }
 
   // premultiply alpha in output as the source PNG is not premultiplied
   if( convertToPremultipliedAlpha == 1 ) {
     layerColor.rgb *= layerColor.a;
   }
+  
   gl_FragColor = layerColor;
 
 }

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -9,11 +9,21 @@ uniform vec2 layerUVScale;
 
 uniform mat3 uvToTexture;
 uniform mat3 uvToMaskTexture;
+
+uniform mat3 uvToImage;
+
 uniform int maskMode;
 
 varying vec3 v_viewPosition;
 varying vec3 v_viewNormal;
 varying vec2 v_uv;
+
+uniform vec2 imgSize;
+uniform vec2 layerSize;
+uniform vec2 layerPos;
+uniform sampler2D imgMap;
+
+uniform int blendMode;
 
 #pragma include <math/math>
 #pragma include <color/spaces/srgb>
@@ -36,20 +46,268 @@ float getMaskValue(){
 
 }
 
+
+// According to https://www.w3.org/TR/compositing-1/#blendingnonseparable
+const vec3 lumaCoef = vec3( 0.3, 0.59, 0.11 );
+
+float minComponent( vec3 color ){
+  return min( color.r, min( color.g, color.b ) );
+}
+
+float maxComponent( vec3 color ){
+  return max( color.r, max( color.g, color.b ) );
+}
+
+float getLuma( vec3 color ){
+  return dot( color, lumaCoef );
+}
+
+float getChroma( vec3 color ){
+  return maxComponent( color ) - minComponent( color );
+}
+
+vec3 _withChroma( vec3 color,  float chroma ){
+
+  float min = minComponent( color );
+  float max = maxComponent( color );
+
+  if( min >= max ){
+    // Gray Color
+    return vec3( 0. );
+  }
+
+  float curChroma = getChroma( color );
+
+  vec3 withSat = (color - min) * chroma / curChroma;
+  return withSat;
+}
+
+vec3 _withLuma( vec3 color, float luma){
+
+  float curLuma = getLuma(color);
+  float dLuma = luma - curLuma;
+
+  // This works because lumaCoef sums to 1.0
+  vec3 withLuma = color + dLuma;
+
+  float min = minComponent( withLuma );
+  float max = maxComponent( withLuma );
+
+  vec3 corrected;
+  if( min < 0.0 ) {
+    corrected = ( withLuma - luma ) * luma / ( luma - min ) + luma;
+  } else if ( max > 1.0 ) {
+    corrected = ( withLuma - luma ) * ( 1.0 - luma ) / ( max - luma ) + luma;
+  } else {
+    corrected = withLuma;
+  }
+
+  return corrected;
+
+}
+
+vec3 mixLCH( vec3 lumaColor, vec3 chromaColor, vec3 hueColor ){
+
+  float targetChroma = getChroma( chromaColor );
+  float targetLuma = getLuma( lumaColor );
+
+  vec3 withChromaHue = _withChroma( hueColor, targetChroma );
+  vec3 withLumaChromaHue = _withLuma( withChromaHue, targetLuma );
+
+  return withLumaChromaHue;
+
+}
+
+vec4 compositeColors(vec4 src, vec4 dst){
+
+  vec3 Sc = src.rgb;
+  vec3 Dc = dst.rgb;
+  float Sa = src.a;
+  float ISa = 1.0 - Sa;
+  float Da = dst.a;
+  float IDa = 1.0 - Da;
+
+  // Clear
+  if( blendMode == 0){
+    return vec4(0.);
+  }
+  // Src
+  if( blendMode == 1){
+    return vec4(src);
+  }
+  // Dst
+  if( blendMode == 2){
+    return vec4(dst);
+  }
+  // SrcOver
+  if( blendMode == 3){
+    return vec4(
+      Sc + Dc*ISa,
+      Sa + Da*ISa
+    );
+  }
+  // DstOver
+  if( blendMode == 4){
+    return vec4(
+      Dc + Sc*IDa,
+      Da + Sa*IDa
+    );
+  }
+  // SrcIn
+  if( blendMode == 5){
+    return vec4(
+      Sc*Da,
+      Sa*Da
+    );
+  }
+  // DstIn
+  if( blendMode == 6){
+    return vec4(
+      Dc*Sa,
+      Sa*Da
+    );
+  }
+  // SrcOut
+  if( blendMode == 7){
+    return vec4(
+      Sc*IDa,
+      Sa*IDa
+    );
+  }
+   // DstOut
+  if( blendMode == 8){
+    return vec4(
+      Dc*ISa,
+      Da*ISa
+    );
+  }
+  // SrcAtop
+  if( blendMode == 9 ){
+    return vec4(
+      Sc*Da + Dc*ISa,
+      Da
+    );
+  }
+  // DstAtop
+  if( blendMode == 10 ){
+    return vec4(
+      Dc*Sa + Sc*IDa,
+      Sa
+    );
+  }
+  // Xor
+  if( blendMode == 11 ){
+    return vec4(
+      Sc * IDa + Dc*ISa,
+      Sa * IDa + Da * ISa
+    );
+  }
+  // Add
+  if( blendMode == 12 ){
+    return vec4(
+      Sc+Dc,
+      Sa+Da
+    );
+  }
+  // Multiply (Matching Html Canvas and Photoshop)
+  if( blendMode == 13 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + Sc * Dc,
+      IDa * Sa + ISa * Da + Sa * Da
+    );
+  }
+  // Screen
+  if( blendMode == 14 ){
+    return vec4(
+      1.0 - (1.0 - Sc) * (1.0 - Dc),
+      1.0 - ISa * IDa
+    );
+  }
+  // Overlay
+  if( blendMode == 15 ){
+    vec3 edge = step( Da * 0.5, Dc );
+    vec3 mul = IDa * Sc + ISa * Dc + 2.0 * Sc * Dc;
+    vec3 screen = Sa * Da - 2.0 * (Da - Sc)* (Sa -Dc);
+
+    return vec4(
+      mix(mul, screen, edge),
+      Sa + Da - Sa * Da
+    );
+  }
+  // Ligthen
+  if( blendMode == 16 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + max(Sc, Dc),
+      Sa + ISa * Da
+    );
+  }
+  // Darken
+  if( blendMode == 17 ){
+    return vec4(
+      IDa * Sc + ISa * Dc + min(Sc, Dc),
+      Sa + ISa * Da
+    );
+  }
+
+  // Hue (Hue from src, Chroma/Luma from dst)
+  if( blendMode == 24 ){ // Double check with inverse
+    vec3 new = mixLCH( Sa * Dc, Dc, Sc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Saturation (Chroma from src, Hue/Luma from dst)
+  if( blendMode == 25 ){
+    vec3 new = mixLCH( Sa * Dc, Sc, Dc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Color ( Hue/Chroma from src, Luma from dst)
+  if( blendMode == 26 ){
+    vec3 new = mixLCH( Sa * Dc, Sc, Sc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  // Luminosity ( Luma from src, Hue/Chroma from dst )
+  if( blendMode == 27 ){
+    vec3 new = mixLCH( Da * Sc, Dc, Dc );
+    return vec4(
+      IDa * Sc + ISa * Dc + new,
+      Sa + ISa * Da
+    );
+  }
+
+  return vec4(0.);
+}
+
 void main() {
-  vec3 outputColor = vec3(0.);
+
+  vec2 imgUv = (( vec2( v_uv.x, 1.0-v_uv.y ) * layerSize + layerPos) / imgSize );
+  imgUv = ( uvToTexture * vec3( imgUv, 1.0 ) ).xy;
+
+  vec4 imgColor = texture2D( imgMap, imgUv, mipmapBias );
+
   vec2 texelUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
 
   vec4 layerColor = texture2D( layerMap, texelUv, mipmapBias );
 
   layerColor *= getMaskValue();
 
+  vec4 outputColor = compositeColors( layerColor, imgColor);
 
   // premultiply alpha in output as the source PNG is not premultiplied
   if( convertToPremultipliedAlpha == 1 ) {
-    layerColor.rgb *= layerColor.a;
+    outputColor.rgb *= outputColor.a;
   }
-  
-  gl_FragColor = layerColor;
+
+  gl_FragColor = outputColor;
 
 }

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -1,25 +1,11 @@
 precision highp float;
 
+uniform sampler2D imageMap;
 uniform sampler2D layerMap;
 uniform sampler2D maskMap;
+
 uniform float mipmapBias;
 uniform int convertToPremultipliedAlpha;
-
-uniform vec2 layerUVScale;
-
-uniform mat3 uvToTexture;
-uniform mat3 uvToMaskTexture;
-
-uniform mat3 uvToImage;
-
-varying vec3 v_viewPosition;
-varying vec3 v_viewNormal;
-varying vec2 v_uv;
-
-uniform vec2 imgSize;
-uniform vec2 layerSize;
-uniform vec2 layerPos;
-uniform sampler2D imgMap;
 
 #pragma include <math/math>
 #pragma include <color/spaces/srgb>
@@ -27,21 +13,19 @@ uniform sampler2D imgMap;
 #pragma include "./mask.frag"
 #pragma include "./blend.frag"
 
+varying vec2 v_image_uv;
+varying vec2 v_layer_uv;
+varying vec2 v_mask_uv;
+
 void main() {
 
-  vec2 imgUv = (( vec2( v_uv.x, 1.0-v_uv.y ) * layerSize + layerPos) / imgSize );
-  imgUv = ( uvToTexture * vec3( imgUv, 1.0 ) ).xy;
+  vec4 imageColor = texture2D( imageMap, v_image_uv, mipmapBias );
+  vec4 layerColor = texture2D( layerMap, v_layer_uv, mipmapBias );
+  vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
 
-  vec4 imgColor = texture2D( imgMap, imgUv, mipmapBias );
+  layerColor *= getMaskValue( maskColor );
 
-  vec2 layerUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
-  vec4 layerColor = texture2D( layerMap, layerUv, mipmapBias );
-
-  vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
-  vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
-  layerColor *= getMaskValue(maskTexel);
-
-  vec4 outputColor = compositeColors( layerColor, imgColor);
+  vec4 outputColor = compositeColors( layerColor, imageColor);
 
   // premultiply alpha in output as the source PNG is not premultiplied
   if( convertToPremultipliedAlpha == 1 ) {

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -1,12 +1,15 @@
 precision highp float;
 
 uniform sampler2D layerMap;
+uniform sampler2D maskMap;
 uniform float mipmapBias;
 uniform int convertToPremultipliedAlpha;
 
 uniform vec2 layerUVScale;
 
 uniform mat3 uvToTexture;
+uniform mat3 uvToMaskTexture;
+uniform int maskMode;
 
 varying vec3 v_viewPosition;
 varying vec3 v_viewNormal;
@@ -20,6 +23,26 @@ void main() {
   vec2 texelUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
 
   vec4 layerColor = texture2D( layerMap, texelUv, mipmapBias );
+
+  if ( maskMode > 0 ) {
+    
+    vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
+    vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
+
+    float maskValue;
+
+    if( maskMode == 2 || maskMode == 4 ) {
+      maskValue = maskTexel.r;
+    } else {
+      maskValue = maskTexel.a;
+    }
+
+    if( maskMode >= 3 ) {
+      maskValue = 1.0 - maskValue;
+    }
+
+    layerColor *= maskValue;
+  }
 
   // premultiply alpha in output as the source PNG is not premultiplied
   if( convertToPremultipliedAlpha == 1 ) {

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -7,8 +7,8 @@ uniform sampler2D maskMap;
 uniform float mipmapBias;
 uniform int convertToPremultipliedAlpha;
 
-#pragma include <math/math>
-#pragma include <color/spaces/srgb>
+uniform int maskMode;
+uniform int blendMode;
 
 #pragma include "./mask.frag"
 #pragma include "./blend.frag"
@@ -19,13 +19,18 @@ varying vec2 v_mask_uv;
 
 void main() {
 
-  vec4 imageColor = texture2D( imageMap, v_image_uv, mipmapBias );
   vec4 layerColor = texture2D( layerMap, v_layer_uv, mipmapBias );
-  vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
+  vec4 outputColor = layerColor;
 
-  layerColor *= getMaskValue( maskColor );
+  if( maskMode != 0){
+    vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
+    outputColor *= getMaskValue( maskColor );
+  }
 
-  vec4 outputColor = compositeColors( layerColor, imageColor);
+  if( blendMode != 0){
+    vec4 imageColor = texture2D( imageMap, v_image_uv, mipmapBias );
+    outputColor = compositeColors( outputColor, imageColor );
+  }
 
   // premultiply alpha in output as the source PNG is not premultiplied
   if( convertToPremultipliedAlpha == 1 ) {

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -36,7 +36,7 @@ void main() {
     // Check ( v >= lower && v <= upper). Rework into (v >= lower && -v >= -upper), which combines to (v,-v) >= (lower, -upper)
     const vec4 comboBounds = vec4( lowerBound, -upperBound );
     vec4 comboValue = vec4( v_mask_uv, -v_mask_uv);
-    bvec4 inBounds = greaterThanEqual(comboValue, vec4(0.,0.,-1.,-1.));
+    bvec4 inBounds = greaterThanEqual(comboValue, comboBounds);
     bool hasMaskData = all(inBounds);
 
     vec4 maskColor = hasMaskData ? texture2D( maskMap, v_mask_uv, mipmapBias ) : vec4(0.);

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -20,21 +20,29 @@ varying vec2 v_mask_uv;
 void main() {
 
   vec4 layerColor = texture2D( layerMap, v_layer_uv, mipmapBias );
+  // premultiply alpha as the source PNG is not premultiplied
+  if( convertToPremultipliedAlpha == 1 ) {
+    layerColor.rgb *= layerColor.a;
+  }
+
   vec4 outputColor = layerColor;
 
-  if( maskMode != 0){
+  if( maskMode != 0 ){
     vec4 maskColor = texture2D( maskMap, v_mask_uv, mipmapBias );
+    // premultiply alpha as the source PNG is not premultiplied
+    if( convertToPremultipliedAlpha == 1 ) {
+      maskColor.rgb *= maskColor.a;
+    }
+
     outputColor *= getMaskValue( maskColor );
   }
 
   if( blendMode != 0){
     vec4 imageColor = texture2D( imageMap, v_image_uv, mipmapBias );
-    outputColor = compositeColors( outputColor, imageColor );
-  }
 
-  // premultiply alpha in output as the source PNG is not premultiplied
-  if( convertToPremultipliedAlpha == 1 ) {
-    outputColor.rgb *= outputColor.a;
+    // Image always comes from premultiplied backbuffer
+
+    outputColor = compositeColors( outputColor, imageColor );
   }
 
   gl_FragColor = outputColor;

--- a/src/lib/engines/layerCompositor/fragment.glsl
+++ b/src/lib/engines/layerCompositor/fragment.glsl
@@ -12,8 +12,6 @@ uniform mat3 uvToMaskTexture;
 
 uniform mat3 uvToImage;
 
-uniform int maskMode;
-
 varying vec3 v_viewPosition;
 varying vec3 v_viewNormal;
 varying vec2 v_uv;
@@ -23,270 +21,11 @@ uniform vec2 layerSize;
 uniform vec2 layerPos;
 uniform sampler2D imgMap;
 
-uniform int blendMode;
-
 #pragma include <math/math>
 #pragma include <color/spaces/srgb>
 
-float getMaskValue(){
-
-  if( maskMode == 0 ) return 1.0;
-
-  vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
-  vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
-
-  float maskValue;
-
-  if ( maskMode == 1 ) return maskTexel.a;
-  if ( maskMode == 2 ) return maskTexel.r;
-  if ( maskMode == 3 ) return 1.0 - maskTexel.a;
-  if ( maskMode == 4 ) return 1.0 - maskTexel.r;
-
-  return 1.0;
-
-}
-
-
-// According to https://www.w3.org/TR/compositing-1/#blendingnonseparable
-const vec3 lumaCoef = vec3( 0.3, 0.59, 0.11 );
-
-float minComponent( vec3 color ){
-  return min( color.r, min( color.g, color.b ) );
-}
-
-float maxComponent( vec3 color ){
-  return max( color.r, max( color.g, color.b ) );
-}
-
-float getLuma( vec3 color ){
-  return dot( color, lumaCoef );
-}
-
-float getChroma( vec3 color ){
-  return maxComponent( color ) - minComponent( color );
-}
-
-vec3 _withChroma( vec3 color,  float chroma ){
-
-  float min = minComponent( color );
-  float max = maxComponent( color );
-
-  if( min >= max ){
-    // Gray Color
-    return vec3( 0. );
-  }
-
-  float curChroma = getChroma( color );
-
-  vec3 withSat = (color - min) * chroma / curChroma;
-  return withSat;
-}
-
-vec3 _withLuma( vec3 color, float luma){
-
-  float curLuma = getLuma(color);
-  float dLuma = luma - curLuma;
-
-  // This works because lumaCoef sums to 1.0
-  vec3 withLuma = color + dLuma;
-
-  float min = minComponent( withLuma );
-  float max = maxComponent( withLuma );
-
-  vec3 corrected;
-  if( min < 0.0 ) {
-    corrected = ( withLuma - luma ) * luma / ( luma - min ) + luma;
-  } else if ( max > 1.0 ) {
-    corrected = ( withLuma - luma ) * ( 1.0 - luma ) / ( max - luma ) + luma;
-  } else {
-    corrected = withLuma;
-  }
-
-  return corrected;
-
-}
-
-vec3 mixLCH( vec3 lumaColor, vec3 chromaColor, vec3 hueColor ){
-
-  float targetChroma = getChroma( chromaColor );
-  float targetLuma = getLuma( lumaColor );
-
-  vec3 withChromaHue = _withChroma( hueColor, targetChroma );
-  vec3 withLumaChromaHue = _withLuma( withChromaHue, targetLuma );
-
-  return withLumaChromaHue;
-
-}
-
-vec4 compositeColors(vec4 src, vec4 dst){
-
-  vec3 Sc = src.rgb;
-  vec3 Dc = dst.rgb;
-  float Sa = src.a;
-  float ISa = 1.0 - Sa;
-  float Da = dst.a;
-  float IDa = 1.0 - Da;
-
-  // Clear
-  if( blendMode == 0){
-    return vec4(0.);
-  }
-  // Src
-  if( blendMode == 1){
-    return vec4(src);
-  }
-  // Dst
-  if( blendMode == 2){
-    return vec4(dst);
-  }
-  // SrcOver
-  if( blendMode == 3){
-    return vec4(
-      Sc + Dc*ISa,
-      Sa + Da*ISa
-    );
-  }
-  // DstOver
-  if( blendMode == 4){
-    return vec4(
-      Dc + Sc*IDa,
-      Da + Sa*IDa
-    );
-  }
-  // SrcIn
-  if( blendMode == 5){
-    return vec4(
-      Sc*Da,
-      Sa*Da
-    );
-  }
-  // DstIn
-  if( blendMode == 6){
-    return vec4(
-      Dc*Sa,
-      Sa*Da
-    );
-  }
-  // SrcOut
-  if( blendMode == 7){
-    return vec4(
-      Sc*IDa,
-      Sa*IDa
-    );
-  }
-   // DstOut
-  if( blendMode == 8){
-    return vec4(
-      Dc*ISa,
-      Da*ISa
-    );
-  }
-  // SrcAtop
-  if( blendMode == 9 ){
-    return vec4(
-      Sc*Da + Dc*ISa,
-      Da
-    );
-  }
-  // DstAtop
-  if( blendMode == 10 ){
-    return vec4(
-      Dc*Sa + Sc*IDa,
-      Sa
-    );
-  }
-  // Xor
-  if( blendMode == 11 ){
-    return vec4(
-      Sc * IDa + Dc*ISa,
-      Sa * IDa + Da * ISa
-    );
-  }
-  // Add
-  if( blendMode == 12 ){
-    return vec4(
-      Sc+Dc,
-      Sa+Da
-    );
-  }
-  // Multiply (Matching Html Canvas and Photoshop)
-  if( blendMode == 13 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + Sc * Dc,
-      IDa * Sa + ISa * Da + Sa * Da
-    );
-  }
-  // Screen
-  if( blendMode == 14 ){
-    return vec4(
-      1.0 - (1.0 - Sc) * (1.0 - Dc),
-      1.0 - ISa * IDa
-    );
-  }
-  // Overlay
-  if( blendMode == 15 ){
-    vec3 edge = step( Da * 0.5, Dc );
-    vec3 mul = IDa * Sc + ISa * Dc + 2.0 * Sc * Dc;
-    vec3 screen = Sa * Da - 2.0 * (Da - Sc)* (Sa -Dc);
-
-    return vec4(
-      mix(mul, screen, edge),
-      Sa + Da - Sa * Da
-    );
-  }
-  // Ligthen
-  if( blendMode == 16 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + max(Sc, Dc),
-      Sa + ISa * Da
-    );
-  }
-  // Darken
-  if( blendMode == 17 ){
-    return vec4(
-      IDa * Sc + ISa * Dc + min(Sc, Dc),
-      Sa + ISa * Da
-    );
-  }
-
-  // Hue (Hue from src, Chroma/Luma from dst)
-  if( blendMode == 24 ){ // Double check with inverse
-    vec3 new = mixLCH( Sa * Dc, Dc, Sc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  // Saturation (Chroma from src, Hue/Luma from dst)
-  if( blendMode == 25 ){
-    vec3 new = mixLCH( Sa * Dc, Sc, Dc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  // Color ( Hue/Chroma from src, Luma from dst)
-  if( blendMode == 26 ){
-    vec3 new = mixLCH( Sa * Dc, Sc, Sc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  // Luminosity ( Luma from src, Hue/Chroma from dst )
-  if( blendMode == 27 ){
-    vec3 new = mixLCH( Da * Sc, Dc, Dc );
-    return vec4(
-      IDa * Sc + ISa * Dc + new,
-      Sa + ISa * Da
-    );
-  }
-
-  return vec4(0.);
-}
+#pragma include "./mask.frag"
+#pragma include "./blend.frag"
 
 void main() {
 
@@ -295,11 +34,12 @@ void main() {
 
   vec4 imgColor = texture2D( imgMap, imgUv, mipmapBias );
 
-  vec2 texelUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
+  vec2 layerUv = ( uvToTexture * vec3( v_uv, 1.0 ) ).xy;
+  vec4 layerColor = texture2D( layerMap, layerUv, mipmapBias );
 
-  vec4 layerColor = texture2D( layerMap, texelUv, mipmapBias );
-
-  layerColor *= getMaskValue();
+  vec2 maskTexelUv = ( uvToMaskTexture * vec3( v_uv, 1.0 ) ).xy;
+  vec4 maskTexel = texture2D( maskMap, maskTexelUv, mipmapBias );
+  layerColor *= getMaskValue(maskTexel);
 
   vec4 outputColor = compositeColors( layerColor, imgColor);
 

--- a/src/lib/engines/layerCompositor/makeMatrix3FromViewToLayerUv.ts
+++ b/src/lib/engines/layerCompositor/makeMatrix3FromViewToLayerUv.ts
@@ -1,0 +1,29 @@
+import { Matrix3 } from "../../math";
+import { makeMatrix3Concatenation, makeMatrix3Scale, makeMatrix3Translation } from "../../math/Matrix3.Functions";
+import { Vector2 } from "../../math/Vector2";
+
+// Takes a layer size, optional offset, and if the layer is a texture or framebuffer.
+// Returns a matrix that transforms from image coordinates ( (0,0) in top left ) to UV coordinates for that layer.
+export function makeMatrix3FromViewToLayerUv(
+  layerSize: Vector2,
+  layerOffset: Vector2 | undefined,
+  layerIsFramebuffer: boolean = false,
+  result = new Matrix3(),
+): Matrix3 {
+  if (layerOffset == null) {
+    result.makeIdentity();
+  } else {
+    makeMatrix3Translation(layerOffset.clone().negate(), result);
+  }
+
+  const invScale = makeMatrix3Scale(new Vector2(1 / layerSize.x, 1 / layerSize.y));
+  result = makeMatrix3Concatenation(invScale, result, result);
+
+  if (layerIsFramebuffer) {
+    // Performs "vec2( pos.x, 1.0 - pos.y );"
+    const flipY = new Matrix3().set(1, 0, 0, 0, -1, 1, 0, 0, 1);
+    result = makeMatrix3Concatenation(flipY, result, result);
+  }
+
+  return result;
+}

--- a/src/lib/engines/layerCompositor/mask.frag
+++ b/src/lib/engines/layerCompositor/mask.frag
@@ -1,0 +1,13 @@
+uniform int maskMode;
+
+float getMaskValue( vec4 maskTexel ){
+
+  if( maskMode == 0 ) return 1.0;
+  if ( maskMode == 1 ) return maskTexel.a;
+  if ( maskMode == 2 ) return maskTexel.r;
+  if ( maskMode == 3 ) return 1.0 - maskTexel.a;
+  if ( maskMode == 4 ) return 1.0 - maskTexel.r;
+
+  return 1.0;
+
+}

--- a/src/lib/engines/layerCompositor/mask.frag
+++ b/src/lib/engines/layerCompositor/mask.frag
@@ -2,7 +2,7 @@ uniform int maskMode;
 
 float getMaskValue( vec4 maskTexel ){
 
-  if( maskMode == 0 ) return 1.0;
+  if ( maskMode == 0 ) return 1.0;
   if ( maskMode == 1 ) return maskTexel.a;
   if ( maskMode == 2 ) return maskTexel.r;
   if ( maskMode == 3 ) return 1.0 - maskTexel.a;

--- a/src/lib/engines/layerCompositor/mask.frag
+++ b/src/lib/engines/layerCompositor/mask.frag
@@ -1,13 +1,12 @@
-uniform int maskMode;
 
+// See LayerMaskMode in Layer.ts for a list of enum values
 float getMaskValue( vec4 maskTexel ){
 
-  if ( maskMode == 0 ) return 1.0;
-  if ( maskMode == 1 ) return maskTexel.a;
-  if ( maskMode == 2 ) return maskTexel.r;
-  if ( maskMode == 3 ) return 1.0 - maskTexel.a;
-  if ( maskMode == 4 ) return 1.0 - maskTexel.r;
-
-  return 1.0;
-
+  if( maskMode < 3 ) {
+    if    ( maskMode == 1 )   return maskTexel.a;
+    else /* maskMode == 2 */  return maskTexel.r;
+  } else {
+    if    ( maskMode == 3 )   return 1.0 - maskTexel.a;
+    else /* maskMode == 4 */  return 1.0 - maskTexel.r;
+  }
 }

--- a/src/lib/engines/layerCompositor/vertex.glsl
+++ b/src/lib/engines/layerCompositor/vertex.glsl
@@ -1,21 +1,35 @@
 attribute vec3 position;
-attribute vec3 normal;
-attribute vec2 uv;
 
-uniform mat4 localToWorld;
-uniform mat4 worldToView;
+uniform mat4 localToView;
 uniform mat4 viewToScreen;
 
-varying vec3 v_viewPosition;
-varying vec3 v_viewNormal;
-varying vec2 v_uv;
+uniform mat3 viewToImageUv;
+uniform mat3 viewToLayerUv;
+uniform mat3 viewToMaskUv;
+
+varying vec2 v_image_uv;
+varying vec2 v_layer_uv;
+varying vec2 v_mask_uv;
+
+vec2 getUv( vec2 globalPosition, vec2 offset, vec2 size, int isFbo ){
+
+  vec2 pos = ( globalPosition - offset ) / size;
+  if( isFbo == 1) pos = vec2( pos.x, 1.0 - pos.y );
+
+  return pos;
+
+}
 
 void main() {
 
-  v_viewNormal = normalize( ( worldToView * localToWorld * vec4( normal, 0. ) ).xyz );
-  v_viewPosition = ( worldToView * localToWorld * vec4( position, 1. ) ).xyz;
-  v_uv = uv;
+  vec4 viewPos = localToView * vec4( position, 1. );
 
-  gl_Position = viewToScreen * vec4( v_viewPosition, 1. );
+  vec3 viewPos2d = vec3( viewPos.xy, 1.0 );
+
+  v_image_uv = ( viewToImageUv * viewPos2d ).xy;
+  v_layer_uv = ( viewToLayerUv * viewPos2d ).xy;
+  v_mask_uv =  ( viewToMaskUv  * viewPos2d ).xy;
+
+  gl_Position = viewToScreen * viewPos;
 
 }


### PR DESCRIPTION
Implementation of layer blending and masking.

**Blending**
Added support for most modes of blending available on HtmlCanvas. 
- The trivial Porter-Duff compositing modes are implemented by setting the blend state.
-  Non trivial blend modes are implemented by first copying part (Only the section we're compositing) of the writeBuffer to a read buffer, and using the read buffer to get the current pixel value. That is then used in the shader code.

**Masking**
Masks specify how much of the layer is composited on the one below. For user convenience, we allow for modes of masking.
- ( Inverse) Luminance: The mask's ( 1.0 - ) luminance is multiplied into the layer's alpha. This is how image softwares usually process masks.
- ( Inverse ) Alpha: The ( 1.0 - ) alpha of the mask is multiplied into the layer's alpha. 

**Shader Changes**
*Coordinates*
Due to having to manage multiple planes at once, the shader works in two steps.
1. It transforms the drawing plane so that it fits the size and position of the main layer.
2. From the coordinates, we use pre-calcualted matrices to calculate the UV to use for each of the Layer, Mask, and Image buffer.

*Branching*
To avoid having to recompile a shader for each blend/mask mode combination, I use an `Int` uniform to choose the modes. To reduce the number of checks, the branches are organized into a decision tree. I added boilerplate comments to clearly show where we are.